### PR TITLE
Define CF_RETURN_* macros on CFBase

### DIFF
--- a/Headers/CoreFoundation/CFBase.h.in
+++ b/Headers/CoreFoundation/CFBase.h.in
@@ -278,6 +278,22 @@ CF_EXPORT const double kCFCoreFoundationVersionNumber;
 /** \} */
 /** \} */
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_feature(attribute_cf_returns_retained)
+#define CF_RETURNS_RETAINED __attribute__((cf_returns_retained))
+#else
+#define CF_RETURNS_RETAINED
+#endif
+
+#if __has_feature(attribute_cf_returns_not_retained)
+#define CF_RETURNS_NOT_RETAINED __attribute__((cf_returns_not_retained))
+#else
+#define CF_RETURNS_NOT_RETAINED
+#endif
+
 /** \ingroup CFPropertyListRef
  */
 typedef CFTypeRef CFPropertyListRef;


### PR DESCRIPTION
Clang allows for cf_returns_retained and cf_returns_not_retained
attributes on CoreFoundation-family functions to annotate whether they
return an object that must later be released or not. The macros
CF_RETURNS_RETAINED and CF_RETURNS_NOT_RETAINED are easier ways to
specify this attribute.

This commit defines this macro on CoreBase for increased compatibility.

(Context: this is required for WebKit to build, since it contains some declarations that use this macro.)