### PR TITLE
Make WebCore build under CoreBase

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,41 @@
+2017-08-23  Stefan Bidigaray <stefanbidi@gmail.com>
+	* Headers/CoreFoundation/CFBase.h.in
+	* Source/CFRuntime.c:	
+	Implement CFAutorelease(), which is supposed to send a CF
+	object into an autorelease pool regardless of ARC.
+
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+	* Headers/CoreFoundation/CFBase.h.in:	
+	Create the CF_OPTIONS() macro, an equivalent to CF_ENUM() for defining
+	enumerations.
+
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+	* Headers/CoreFoundation/CFRunLoop.h:	
+	Redefine the `CFRunLoopActivity` enum type to allow it to be mixed in
+	bitwise-OR operations with other types in C++, thus increasing
+	compatibility with the reference platform.
+
+2017-08-04  Daniel Ferreira <bnmvco@gmail.com>
+	* Headers/CoreFoundation/CFBase.h.in
+	* Source/CFRuntime.c:	
+	Automatic Reference Counting (ARC) can only handle the memory management
+	of Objective-C objects and not that of C structs. To preserve the ease
+	of toll-free bridging, ARC has added the __bridge_retained and
+	__bridge_transfer directives for casting between these two types.
+
+	__bridge_retained specifies that an Objective-C object should be cast to
+	a C struct and that the struct needs to be manually released.
+	__bridge_transfer works the other way, and turns a C struct that would
+	need a manual release into an object that is now managed by ARC and no
+	longer needs that.
+
+	The Apple CoreFoundation API specifies the CFBridgingRetain() and
+	CFBridgingRelease() functions that do, respectively, the same things
+	these directives do. This commit implements these two functions exactly
+	as the compiler would handle the directives.
+
+	This change was co-authored with Stefan Bidigaray.
+
 2017-06-30  Daniel Ferreira <dtf@stanford.edu>
 	* Source/CFPropertyList.c:	
 	The CFPropertyListCreateWithStream() documentation allows for a

--- a/Headers/CoreFoundation/CFBase.h.in
+++ b/Headers/CoreFoundation/CFBase.h.in
@@ -221,6 +221,7 @@ typedef CFComparisonResult (*CFComparatorFunction) (const void *val1,
 
 /* CFEnum macro for type definitions */
 #define CF_ENUM(_type, _name) _type _name; enum
+#define CF_OPTIONS(_type, _name) _type _name; enum
 
 /* CoreFoundation version numbers */
 /** \name Library Version Numbers

--- a/Headers/CoreFoundation/CFBase.h.in
+++ b/Headers/CoreFoundation/CFBase.h.in
@@ -442,6 +442,22 @@ CF_EXPORT CFTypeRef CFMakeCollectable (CFTypeRef cf);
 CF_EXPORT void CFRelease (CFTypeRef cf);
 
 CF_EXPORT CFTypeRef CFRetain (CFTypeRef cf);
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+CF_EXPORT void *_CFBridgingRelease (CFTypeRef cf);
+CF_EXPORT CFTypeRef _CFBridgingRetain (void *obj);
+
+#if __has_feature(objc_arc)
+#define CFBridgingRetain(x) (__bridge_retained CFTypeRef)(x)
+#define CFBridgingRelease(x) (__bridge_transfer id)(x)
+#elif __OBJC__
+#define CFBridgingRetain(x) _CFBridgingRetain((void *)(x))
+#define CFBridgingRelease(x) (id)_CFBridgingRelease((x))
+#else
+#define CFBridgingRetain(x) _CFBridgingRetain((void *)(x))
+#define CFBridgingRelease(x) _CFBridgingRelease((x))
+#endif
+#endif
 /** \} */
 
 

--- a/Headers/CoreFoundation/CFBase.h.in
+++ b/Headers/CoreFoundation/CFBase.h.in
@@ -444,6 +444,8 @@ CF_EXPORT void CFRelease (CFTypeRef cf);
 
 CF_EXPORT CFTypeRef CFRetain (CFTypeRef cf);
 
+CF_EXPORT CFTypeRef CFAutorelease(CFTypeRef arg);
+
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
 CF_EXPORT void *_CFBridgingRelease (CFTypeRef cf);
 CF_EXPORT CFTypeRef _CFBridgingRetain (void *obj);

--- a/Headers/CoreFoundation/CFRunLoop.h
+++ b/Headers/CoreFoundation/CFRunLoop.h
@@ -212,7 +212,7 @@ CF_EXPORT CFTypeID CFRunLoopSourceGetTypeID (void);
 /** \defgroup CFRunLoopObserverRef CFRunLoopObserver Reference
     \{
  */
-typedef enum
+enum
 {
   kCFRunLoopEntry = (1 << 0),
   kCFRunLoopBeforeTimers = (1 << 1),
@@ -221,7 +221,8 @@ typedef enum
   kCFRunLoopAfterWaiting = (1 << 6),
   kCFRunLoopExit = (1 << 7),
   kCFRunLoopAllActivities = 0x0FFFFFFFU
-} CFRunLoopActivity;
+};
+typedef int CFRunLoopActivity;
 
 typedef void (*CFRunLoopObserverCallBack) (CFRunLoopObserverRef observer,
                                            CFRunLoopActivity activity,

--- a/Source/CFRuntime.c
+++ b/Source/CFRuntime.c
@@ -384,6 +384,18 @@ CFRetain (CFTypeRef cf)
   return cf;
 }
 
+void *
+_CFBridgingRelease (CFTypeRef cf)
+{
+  CF_OBJC_FUNCDISPATCHV(CFTypeRef, void *, cf, "autorelease");
+}
+
+CFTypeRef
+_CFBridgingRetain (void *obj)
+{
+  CF_OBJC_FUNCDISPATCHV(void *, CFTypeRef, obj, "retain");
+}
+
 const void *
 CFTypeRetainCallBack (CFAllocatorRef allocator, const void *value)
 {

--- a/Source/CFRuntime.c
+++ b/Source/CFRuntime.c
@@ -384,6 +384,16 @@ CFRetain (CFTypeRef cf)
   return cf;
 }
 
+CFTypeRef
+CFAutorelease (CFTypeRef cf)
+{
+#if __has_feature(objc_arc)
+  return objc_autoreleaseReturnValue(cf);
+#else
+  CF_OBJC_FUNCDISPATCHV(CFTypeRef, CFTypeRef, cf, "autorelease");
+#endif
+}
+
 void *
 _CFBridgingRelease (CFTypeRef cf)
 {


### PR DESCRIPTION
This pull request contains the last changes required for WebCore to build under CoreBase.

Those are:

* An attempt at the `CFBridging*` issue raised long ago;
* A quick enum definition fix;
* A stub for `CFAutorelease()`, which currently I have no idea of how to implement.