### PR TITLE
Added configure check to link against libm.

### DIFF
--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -30,6 +30,9 @@
 /* Define to 1 if you have the `dispatch' library (-ldispatch). */
 #undef HAVE_LIBDISPATCH
 
+/* Define to 1 if you have the `m' library (-lm). */
+#undef HAVE_LIBM
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/configure
+++ b/configure
@@ -5175,6 +5175,55 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+#---
+# Check for libm
+#---
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for modf in -lm" >&5
+$as_echo_n "checking for modf in -lm... " >&6; }
+if ${ac_cv_lib_m_modf+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lm  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char modf ();
+int
+main ()
+{
+return modf ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_m_modf=yes
+else
+  ac_cv_lib_m_modf=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_m_modf" >&5
+$as_echo "$ac_cv_lib_m_modf" >&6; }
+if test "x$ac_cv_lib_m_modf" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBM 1
+_ACEOF
+
+  LIBS="-lm $LIBS"
+
+fi
+
+
 ac_config_files="$ac_config_files Source/GNUmakefile Headers/CoreFoundation/CFBase.h"
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,11 @@ AC_MSG_RESULT($with_zoneinfo)
 AC_DEFINE_UNQUOTED([TZDIR], ["$with_zoneinfo"],
   [Define to the directory contain time zone object files.])
 
+#---
+# Check for libm
+#---
+AC_CHECK_LIB(m, modf)
+
 AC_CONFIG_FILES([Source/GNUmakefile Headers/CoreFoundation/CFBase.h])
 
 AC_OUTPUT


### PR DESCRIPTION
Functions from libm are used e.g. in CFDate.

Fixes runtime link errors on certain platforms (e.g. Android 5.0).