### PR TITLE
Added ICU_LIBS to GNUmakefile dependencies.

### DIFF
--- a/Source/GNUmakefile.in
+++ b/Source/GNUmakefile.in
@@ -105,7 +105,7 @@ libgnustep-corebase_OBJC_FILES = \
   NSCFDate.m \
   NSCFType.m
 
-libgnustep-corebase_LIBRARIES_DEPEND_UPON += @LIBS@ $(FND_LIBS)
+libgnustep-corebase_LIBRARIES_DEPEND_UPON += @LIBS@ @ICU_LIBS@ $(FND_LIBS)
 libgnustep-corebase_HEADER_FILES_DIR = ../Headers/CoreFoundation
 libgnustep-corebase_HEADER_FILES_INSTALL_DIR = CoreFoundation
 


### PR DESCRIPTION
With the recent switch to use pkg-config for ICU (https://github.com/gnustep/libs-corebase/commit/3c56174835d9e300fb0a44ba3c774e1e7eaf8c1c), the ICU libraries are now stored in `ICU_LIBS` instead of `LIBS`. This adds `ICU_LIBS` to the dependencies in GNUmakefile.in.