### PR TITLE
Toll-free bridging of CF to NSNumber and added tests.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,9 @@
 2020-03-06  Frederik Seiffert <frederik@algoriddim.com>
-    * Source/GNUmakefile.in
-	* Source/NSCFNumber.c:
-    * Source/NSCFType.c:
-    Implement toll-free bridging of CFNumber to NSNumber.
-    * Tests/CFNumber/bridge.m:
-    Add CFNumber bridging tests.
+	* Source/GNUmakefile.in,
+	* Source/NSCFNumber.m,
+	* Source/NSCFType.m: Implement toll-free bridging of CFNumber
+	to NSNumber.
+	* Tests/CFNumber/bridge.m: Add CFNumber bridging tests.
     
 2019-11-15  Stefan Bidigaray <stefanbidi@gmail.com>
 	* Source/CFNumber.c: Implement toll-free bridging in

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2020-03-06  Frederik Seiffert <frederik@algoriddim.com>
+    * Source/GNUmakefile.in
+	* Source/NSCFNumber.c:
+    * Source/NSCFType.c:
+    Implement toll-free bridging of CFNumber to NSNumber.
+    * Tests/CFNumber/bridge.m:
+    Add CFNumber bridging tests.
+    
 2019-11-15  Stefan Bidigaray <stefanbidi@gmail.com>
 	* Source/CFNumber.c: Implement toll-free bridging in
 	CFNumberGetValue().

--- a/Source/GNUmakefile.in
+++ b/Source/GNUmakefile.in
@@ -98,6 +98,7 @@ libgnustep-corebase_OBJC_FILES = \
   NSCFString.m \
   NSCFSet.m \
   NSCFLocale.m \
+  NSCFNumber.m \
   NSCFDictionary.m \
   NSCFTimeZone.m \
   NSCFInputStream.m \

--- a/Source/NSCFNumber.m
+++ b/Source/NSCFNumber.m
@@ -1,0 +1,198 @@
+/* NSCFNumber.m
+   
+   Copyright (C) 2020 Free Software Foundation, Inc.
+   
+   Written by: Frederik Seiffert
+   Date: March, 2020
+   
+   This file is part of the GNUstep CoreBase Library.
+   
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the 
+   Free Software Foundation, 51 Franklin Street, Fifth Floor, 
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSValue.h>
+
+#include "NSCFType.h"
+#include "CoreFoundation/CFNumber.h"
+
+@interface NSCFNumber : NSNumber
+NSCFTYPE_VARS
+@end
+
+@interface NSNumber (CoreBaseAdditions)
+- (CFTypeID) _cfTypeID;
+@end
+
+@implementation NSCFNumber
++ (void) load
+{
+  NSCFInitialize ();
+}
+
++ (void) initialize
+{
+  GSObjCAddClassBehavior (self, [NSCFType class]);
+}
+
+- (const char *) objCType
+{
+  CFNumberType type = CFNumberGetType((CFNumberRef)self);
+  switch (type)
+    {
+      case kCFNumberSInt8Type:
+        return @encode(SInt8);
+      case kCFNumberSInt16Type:
+        return @encode(SInt16);
+      case kCFNumberSInt32Type:
+        return @encode(SInt32);
+      case kCFNumberSInt64Type:
+        return @encode(SInt64);
+      case kCFNumberFloat32Type:
+        return @encode(Float32);
+      case kCFNumberFloat64Type:
+        return @encode(Float64);
+      case kCFNumberCharType:
+        return @encode(char);
+      case kCFNumberShortType:
+        return @encode(short);
+      case kCFNumberIntType:
+        return @encode(int);
+      case kCFNumberLongType:
+        return @encode(long);
+      case kCFNumberLongLongType:
+        return @encode(long long);
+      case kCFNumberFloatType:
+        return @encode(float);
+      case kCFNumberDoubleType:
+        return @encode(double);
+      case kCFNumberCFIndexType:
+        return @encode(CFIndex);
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+      case kCFNumberNSIntegerType:
+        return @encode(NSInteger);
+      case kCFNumberCGFloatType:
+        return @encode(CGFloat);
+#endif
+    }
+    return NULL;
+}
+
+- (NSString*) descriptionWithLocale: (id)aLocale
+{
+  return AUTORELEASE((id) CFCopyDescription(self));
+}
+
+- (BOOL) boolValue
+{
+  BOOL value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberCharType, &value);
+  return value;
+}
+
+- (signed char) charValue
+{
+  signed char value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberCharType, &value);
+  return value;
+}
+
+- (double) doubleValue
+{
+  double value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberDoubleType, &value);
+  return value;
+}
+
+- (float) floatValue
+{
+  float value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberFloatType, &value);
+  return value;
+}
+
+- (signed int) intValue
+{
+  signed int value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberIntType, &value);
+  return value;
+}
+
+- (signed long) longValue
+{
+  signed long value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberLongType, &value);
+  return value;
+}
+
+- (signed long long) longLongValue
+{
+  signed long long value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberLongLongType, &value);
+  return value;
+}
+
+- (signed short) shortValue
+{
+  signed short value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberShortType, &value);
+  return value;
+}
+
+- (unsigned char) unsignedCharValue
+{
+  unsigned char value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberCharType, &value);
+  return value;
+}
+
+- (unsigned int) unsignedIntValue
+{
+  unsigned int value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberIntType, &value);
+  return value;
+}
+
+- (unsigned long) unsignedLongValue
+{
+  unsigned long value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberLongType, &value);
+  return value;
+}
+
+- (unsigned long long) unsignedLongLongValue
+{
+  unsigned long long value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberLongLongType, &value);
+  return value;
+}
+
+- (unsigned short) unsignedShortValue
+{
+  unsigned short value;
+  CFNumberGetValue((CFNumberRef)self, kCFNumberShortType, &value);
+  return value;
+}
+
+@end
+
+@implementation NSNumber (CoreBaseAdditions)
+- (CFTypeID) _cfTypeID
+{
+  return CFNumberGetTypeID();
+}
+@end

--- a/Source/NSCFType.m
+++ b/Source/NSCFType.m
@@ -62,6 +62,7 @@ void NSCFInitialize (void)
       CFRuntimeBridgeClass (CFStringGetTypeID(), "NSCFString");
       CFRuntimeBridgeClass (CFSetGetTypeID(), "NSCFSet");
       CFRuntimeBridgeClass (CFLocaleGetTypeID(), "NSCFLocale");
+      CFRuntimeBridgeClass (CFNumberGetTypeID(), "NSCFNumber");
       CFRuntimeBridgeClass (CFDictionaryGetTypeID(), "NSCFDictionary");
       CFRuntimeBridgeClass (CFTimeZoneGetTypeID(), "NSCFTimeZone");
       CFRuntimeBridgeClass (CFReadStreamGetTypeID(), "NSCFInputStream");

--- a/Tests/CFNumber/bridge.m
+++ b/Tests/CFNumber/bridge.m
@@ -1,0 +1,177 @@
+#import <Foundation/NSValue.h>
+#include "CoreFoundation/CFNumber.h"
+#include "../CFTesting.h"
+
+static signed int sints[] = {INT_MIN, INT_MAX, 0, -1, 1};
+static signed short sshorts[] = {SHRT_MIN, SHRT_MAX, 0, -1, 1};
+static signed char schars[] = {CHAR_MIN, CHAR_MAX, 0, -1, 1};
+static unsigned int uints[] = {UINT_MAX, 0, 1};
+static unsigned short ushorts[] = {USHRT_MAX, 0, 1};
+static unsigned char uchars[] = {UCHAR_MAX, 0, 1};
+static float floats[] = {FLT_MIN, FLT_MAX, FLT_EPSILON, 0, -3.4, 3.4};
+static double doubles[] = {DBL_MIN, DBL_MAX, DBL_EPSILON, 0, -3.4, 3.4};
+
+void testNSonCF(void);
+void testCFonNS(void);
+
+int main(void)
+{
+  testNSonCF();
+  testCFonNS();
+  return 0;
+}
+
+void testNSonCF(void)
+{
+  int i;
+  
+  for (i = 0; i < sizeof(sints)/sizeof(*sints); i++) {
+    signed int in = sints[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberIntType, &in);
+    signed int out = [(NSNumber*)cfnum intValue];
+    PASS_CF(in == out,
+      "-intValue = %d works on CFNumber(kCFNumberIntType) %d", out, in);
+  }
+  
+  for (i = 0; i < sizeof(sshorts)/sizeof(*sshorts); i++) {
+    signed short in = sshorts[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberShortType, &in);
+    signed short out = [(NSNumber*)cfnum shortValue];
+    PASS_CF(in == out,
+      "-shortValue = %d works on CFNumber(kCFNumberShortType) %d", out, in);
+  }
+  
+  for (i = 0; i < sizeof(schars)/sizeof(*schars); i++) {
+    signed char in = schars[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberCharType, &in);
+    signed char out = [(NSNumber*)cfnum charValue];
+    PASS_CF(in == out,
+      "-charValue = %d works on CFNumber(kCFNumberCharType) %d", out, in);
+  }
+  
+  for (i = 0; i < sizeof(uints)/sizeof(*uints); i++) {
+    unsigned int in = uints[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberIntType, &in);
+    unsigned int out = [(NSNumber*)cfnum unsignedIntValue];
+    PASS_CF(in == out,
+      "-unsignedIntValue = %u works on CFNumber(kCFNumberIntType) %u", out, in);
+  }
+  
+  for (i = 0; i < sizeof(ushorts)/sizeof(*ushorts); i++) {
+    unsigned short in = ushorts[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberShortType, &in);
+    unsigned short out = [(NSNumber*)cfnum unsignedShortValue];
+    PASS_CF(in == out,
+      "-unsignedShortValue = %u works on CFNumber(kCFNumberShortType) %u", out, in);
+  }
+  
+  for (i = 0; i < sizeof(uchars)/sizeof(*uchars); i++) {
+    unsigned char in = uchars[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberCharType, &in);
+    unsigned char out = [(NSNumber*)cfnum unsignedCharValue];
+    PASS_CF(in == out,
+      "-unsignedCharValue = %u works on CFNumber(kCFNumberCharType) %u", out, in);
+  }
+  
+  for (i = 0; i < sizeof(floats)/sizeof(*floats); i++) {
+    float in = floats[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberFloatType, &in);
+    float out = [(NSNumber*)cfnum floatValue];
+    PASS_CF(in == out,
+      "-floatValue = %f works on CFNumber(kCFNumberFloatType) %f", out, in);
+  }
+  
+  for (i = 0; i < sizeof(doubles)/sizeof(*doubles); i++) {
+    double in = doubles[i];
+    CFNumberRef cfnum = CFNumberCreate(NULL, kCFNumberDoubleType, &in);
+    double out = [(NSNumber*)cfnum doubleValue];
+    PASS_CF(in == out,
+      "-doubleValue = %lf works on CFNumber(kCFNumberDoubleType) %lf", out, in);
+  }
+}
+
+void testCFonNS(void)
+{
+  int i;
+  
+  for (i = 0; i < sizeof(sints)/sizeof(*sints); i++) {
+    signed int in = sints[i];
+    signed int out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithInt:in],
+      kCFNumberIntType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberIntType) = %d works on signed NSNumber %d",
+      out, in);
+  }
+
+  for (i = 0; i < sizeof(sshorts)/sizeof(*sshorts); i++) {
+    signed short in = sshorts[i];
+    signed short out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithShort:in],
+      kCFNumberShortType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberShortType) = %d works on signed NSNumber %d",
+      out, in);
+  }
+
+  for (i = 0; i < sizeof(schars)/sizeof(*schars); i++) {
+    signed char in = schars[i];
+    signed char out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithChar:in],
+      kCFNumberCharType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberCharType) = %d works on signed NSNumber %d",
+      out, in);
+  }
+
+  for (i = 0; i < sizeof(uints)/sizeof(*uints); i++) {
+    unsigned int in = uints[i];
+    unsigned int out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithUnsignedInt:in],
+      kCFNumberIntType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberIntType) = %u works on unsigned NSNumber %u",
+      out, in);
+  }
+
+  for (i = 0; i < sizeof(ushorts)/sizeof(*ushorts); i++) {
+    unsigned short in = ushorts[i];
+    unsigned short out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithUnsignedShort:in],
+      kCFNumberShortType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberShortType) = %u works on unsigned NSNumber %u",
+      out, in);
+  }
+
+  for (i = 0; i < sizeof(uchars)/sizeof(*uchars); i++) {
+    unsigned char in = uchars[i];
+    unsigned char out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithUnsignedChar:in],
+      kCFNumberCharType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberCharType) = %u works on unsigned NSNumber %u",
+      out, in);
+  }
+  
+  for (i = 0; i < sizeof(floats)/sizeof(*floats); i++) {
+    float in = floats[i];
+    float out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithFloat:in],
+      kCFNumberFloatType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberFloatType) = %f works on NSNumber %f",
+      out, in);
+  }
+  
+  for (i = 0; i < sizeof(doubles)/sizeof(*doubles); i++) {
+    double in = doubles[i];
+    double out;
+    CFNumberGetValue((CFNumberRef)[NSNumber numberWithDouble:in],
+      kCFNumberDoubleType, &out);
+    PASS_CF(in == out,
+      "CFNumberGetValue(kCFNumberDoubleType) = %lf works on NSNumber %lf",
+      out, in);
+  }
+}
+


### PR DESCRIPTION
This adds an implementation for toll-free bridging CFNumber to NSNumber types.

Also added CFNumber bridging tests. Unfortunately though, some of the tests are failing with this error:

> Uncaught exception NSInvalidArgumentException, reason: GSFFIInvocation: Class 'NSSmallInt'(instance) does not respond to forwardInvocation: for 'objCType'

<details><summary>Full output and stack trace</summary>
<p>

```
Running CFNumber/bridge.m...
Passed test:     bridge.m:33 ... -intValue = -2147483648 works on CFNumber(kCFNumberIntType) -2147483648
Passed test:     bridge.m:33 ... -intValue = 2147483647 works on CFNumber(kCFNumberIntType) 2147483647
Passed test:     bridge.m:33 ... -intValue = 0 works on CFNumber(kCFNumberIntType) 0
Passed test:     bridge.m:33 ... -intValue = -1 works on CFNumber(kCFNumberIntType) -1
Passed test:     bridge.m:33 ... -intValue = 1 works on CFNumber(kCFNumberIntType) 1
Passed test:     bridge.m:41 ... -shortValue = -32768 works on CFNumber(kCFNumberShortType) -32768
Passed test:     bridge.m:41 ... -shortValue = 32767 works on CFNumber(kCFNumberShortType) 32767
Passed test:     bridge.m:41 ... -shortValue = 0 works on CFNumber(kCFNumberShortType) 0
Passed test:     bridge.m:41 ... -shortValue = -1 works on CFNumber(kCFNumberShortType) -1
Passed test:     bridge.m:41 ... -shortValue = 1 works on CFNumber(kCFNumberShortType) 1
Passed test:     bridge.m:49 ... -charValue = -128 works on CFNumber(kCFNumberCharType) -128
Passed test:     bridge.m:49 ... -charValue = 127 works on CFNumber(kCFNumberCharType) 127
Passed test:     bridge.m:49 ... -charValue = 0 works on CFNumber(kCFNumberCharType) 0
Passed test:     bridge.m:49 ... -charValue = -1 works on CFNumber(kCFNumberCharType) -1
Passed test:     bridge.m:49 ... -charValue = 1 works on CFNumber(kCFNumberCharType) 1
Passed test:     bridge.m:57 ... -unsignedIntValue = 4294967295 works on CFNumber(kCFNumberIntType) 4294967295
Passed test:     bridge.m:57 ... -unsignedIntValue = 0 works on CFNumber(kCFNumberIntType) 0
Passed test:     bridge.m:57 ... -unsignedIntValue = 1 works on CFNumber(kCFNumberIntType) 1
Passed test:     bridge.m:65 ... -unsignedShortValue = 65535 works on CFNumber(kCFNumberShortType) 65535
Passed test:     bridge.m:65 ... -unsignedShortValue = 0 works on CFNumber(kCFNumberShortType) 0
Passed test:     bridge.m:65 ... -unsignedShortValue = 1 works on CFNumber(kCFNumberShortType) 1
Passed test:     bridge.m:73 ... -unsignedCharValue = 255 works on CFNumber(kCFNumberCharType) 255
Passed test:     bridge.m:73 ... -unsignedCharValue = 0 works on CFNumber(kCFNumberCharType) 0
Passed test:     bridge.m:73 ... -unsignedCharValue = 1 works on CFNumber(kCFNumberCharType) 1
Passed test:     bridge.m:81 ... -floatValue = 0.000000 works on CFNumber(kCFNumberFloatType) 0.000000
Passed test:     bridge.m:81 ... -floatValue = 340282346638528859811704183484516925440.000000 works on CFNumber(kCFNumberFloatType) 340282346638528859811704183484516925440.000000
Passed test:     bridge.m:81 ... -floatValue = 0.000000 works on CFNumber(kCFNumberFloatType) 0.000000
Passed test:     bridge.m:81 ... -floatValue = 0.000000 works on CFNumber(kCFNumberFloatType) 0.000000
Passed test:     bridge.m:81 ... -floatValue = -3.400000 works on CFNumber(kCFNumberFloatType) -3.400000
Passed test:     bridge.m:81 ... -floatValue = 3.400000 works on CFNumber(kCFNumberFloatType) 3.400000
Passed test:     bridge.m:89 ... -doubleValue = 0.000000 works on CFNumber(kCFNumberDoubleType) 0.000000
Passed test:     bridge.m:89 ... -doubleValue = 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000 works on CFNumber(kCFNumberDoubleType) 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000
Passed test:     bridge.m:89 ... -doubleValue = 0.000000 works on CFNumber(kCFNumberDoubleType) 0.000000
Passed test:     bridge.m:89 ... -doubleValue = 0.000000 works on CFNumber(kCFNumberDoubleType) 0.000000
Passed test:     bridge.m:89 ... -doubleValue = -3.400000 works on CFNumber(kCFNumberDoubleType) -3.400000
Passed test:     bridge.m:89 ... -doubleValue = 3.400000 works on CFNumber(kCFNumberDoubleType) 3.400000
Passed test:     bridge.m:105 ... CFNumberGetValue(kCFNumberIntType) = -2147483648 works on signed NSNumber -2147483648
Passed test:     bridge.m:105 ... CFNumberGetValue(kCFNumberIntType) = 2147483647 works on signed NSNumber 2147483647
Passed test:     bridge.m:105 ... CFNumberGetValue(kCFNumberIntType) = 0 works on signed NSNumber 0
Passed test:     bridge.m:105 ... CFNumberGetValue(kCFNumberIntType) = -1 works on signed NSNumber -1
Passed test:     bridge.m:105 ... CFNumberGetValue(kCFNumberIntType) = 1 works on signed NSNumber 1
: Uncaught exception NSInvalidArgumentException, reason: GSFFIInvocation: Class 'NSSmallInt'(instance) does not respond to forwardInvocation: for 'objCType'
/usr/local/bin/gnustep-tests: line 309:  6388 Aborted                 $RUN_CMD
Failed file:     bridge.m aborted without running all tests!
```

**Stack trace:**
```
#0  _NSFoundationUncaughtExceptionHandler (exception=0x78e7c8) at NSException.m:1381
#1  0x00007ffff77038c6 in callUncaughtHandler (value=0x78e7c8) at NSException.m:1415
#2  0x00007ffff6bd8340 in objc_exception_throw (object=0x78e7c8) at /vagrant/libobjc2/eh_personality.c:185
#3  0x00007ffff77047b2 in -[NSException raise] (self=0x78e7c8, _cmd=0x7ffff7ce3188 <.objc_selector_list+592>) at NSException.m:1586
#4  0x00007ffff7703b76 in +[NSException raise:format:arguments:] (self=0x7ffff7ce2cc0 <_OBJC_CLASS_NSException>, _cmd=0x7ffff7ce3018 <.objc_selector_list+224>, name=0x7ffff7ce2880 <.objc_str.84>, format=0x7ffff7d14b50 <.objc_str.78>, 
    argList=0x7fffffffde20) at NSException.m:1465
#5  0x00007ffff7703abd in +[NSException raise:format:] (self=0x7ffff7ce2cc0 <_OBJC_CLASS_NSException>, _cmd=0x7ffff7d160e8 <.objc_selector_list+848>, name=0x7ffff7ce2880 <.objc_str.84>, format=0x7ffff7d14b50 <.objc_str.78>) at NSException.m:1450
#6  0x00007ffff777695e in -[NSObject doesNotRecognizeSelector:] (self=0x60bec0, _cmd=0x7ffff7d16118 <.objc_selector_list+896>, aSelector=0x7ffff7c9c608 <.objc_selector_list+656>) at NSObject.m:1738
#7  0x00007ffff7776a43 in -[NSObject forwardInvocation:] (self=0x60bec0, _cmd=0x7ffff7d87928 <.objc_selector_list+352>, anInvocation=0x789358) at NSObject.m:1759
#8  0x00007ffff789a716 in GSFFIInvocationCallback (cif=0x77da60, retp=0x7fffffffe1d0, args=0x7fffffffe040, user=0x77da18) at GSFFIInvocation.m:606
#9  0x00007ffff53b0d4f in ffi_closure_unix64_inner () from /usr/lib/x86_64-linux-gnu/libffi.so.6
#10 0x00007ffff53b10c8 in ffi_closure_unix64 () from /usr/lib/x86_64-linux-gnu/libffi.so.6
#11 0x0000000000401095 in testNSonCF () at bridge.m:31
#12 0x0000000000401014 in main () at bridge.m:19
```

</p>
</details>

This seems to happen e.g. when calling `CFNumberGetValue()` on a small short and specifying `kCFNumberShortType`. I’m not entirely sure what the root cause of this is. Any pointers would be appreciated.