### PR TITLE
Fix second hash function for double hashing.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-10  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/GSHashTable.c: Fix second hash function for double hashing
+    collision case to avoid possible infinite loop.
+
 2019-11-15  Stefan Bidigaray <stefanbidi@gmail.com>
 	* Source/CFNumber.c: Implement toll-free bridging in
 	CFNumberGetValue().

--- a/Source/GSHashTable.c
+++ b/Source/GSHashTable.c
@@ -155,21 +155,6 @@ GSHashTableRemoveKeyValuePair (GSHashTableRef table, GSHashTableBucket * bucket)
   bucket->value = NULL;
 }
 
-CF_INLINE CFHashCode
-GSHash2 (CFHashCode value)
-{
-/* Knuth's hash function.  We add the 1 to make sure the answer is never
- * zero.
- */
-#if defined(__LP64__) || defined(_WIN64)
-/* 64-bit operating systems */
-  return (CFHashCode) (((UInt64) value + 1) * 2654435761UL);
-#else
-/* 32-bit operating systems */
-  return (CFHashCode) (((UInt32) value + 1) * 2654435761UL);
-#endif
-}
-
 static GSHashTableBucket *
 GSHashTableFindBucket (GSHashTableRef table, const void *key)
 {
@@ -192,7 +177,7 @@ GSHashTableFindBucket (GSHashTableRef table, const void *key)
 
   if (!matched)
     {
-      CFHashCode hash2 = GSHash2 (hash);
+      CFHashCode hash2 = 1 + ((hash / capacity) % (capacity - 1));
 
       if (fEqual)
         {


### PR DESCRIPTION
Changes second hash function to ensure it’s not a multiple of the capacity, which would cause an infinite loop.

I’m not sure if the new hash function is the best, but it should hopefully do the job. However I’m no expert at hash tables and happy to change it to something better.

Fixes #12.