### PR TITLE
Fix hash table logic when removing values.

### DIFF
--- a/Tests/CFArray/bridge.m
+++ b/Tests/CFArray/bridge.m
@@ -29,7 +29,7 @@ void testNSonCF(void)
   PASS_CF([nsarray count] == count,
     "-count works on a CFArray");
 
-  [nsarray addObject: CFSTR("5")];
+  [nsarray addObject: (id)CFSTR("5")];
 
   PASS_CF([nsarray count] == count+1,
     "-addObject: adds a value into a CFArray");

--- a/Tests/CFDictionary/general.m
+++ b/Tests/CFDictionary/general.m
@@ -7,15 +7,16 @@ int main (void)
   CFMutableDictionaryRef cfdict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
   int keys[] = {48, 33, 39, 44, 47, 56, 59, 54, 58, 71, 63, 61, 77, 64, 68, 60, 65, 70, 73, 84, 82, 75};
   int key, value, i;
-  CFNumberRef cfkey, cfvalue;
+  int removeCount, count = sizeof(keys)/sizeof(*keys);
+  CFTypeRef cfkey, cfvalue;
 
-  for (i = 0; i < sizeof(keys)/sizeof(*keys); i++) {
+  for (i = 0; i < count; i++) {
     key = keys[i];
     cfkey = CFNumberCreate (NULL, kCFNumberIntType, &key);
     cfvalue = CFNumberCreate (NULL, kCFNumberIntType, &i);
     CFDictionarySetValue(cfdict, cfkey, cfvalue);
     CFNumberRef cfvalue2 = CFDictionaryGetValue(cfdict, cfkey);
-    PASS_CF(CFEqual(cfvalue, cfvalue2), "set and get values are equal");
+    PASS_CFEQ(cfvalue, cfvalue2, "set and get values are equal");
     CFRelease(cfkey);
     CFRelease(cfvalue);
   }
@@ -25,7 +26,7 @@ int main (void)
   PASS_CF(CFDictionaryGetValue(cfdict, cfkey) == NULL, "CFDictionaryGetValue returns NULL for nonexistant key");
   CFRelease(cfkey);
   
-  for (i = 0; i < sizeof(keys)/sizeof(*keys); i++) {
+  for (i = 0; i < count; i++) {
     key = keys[i];
     cfkey = CFNumberCreate (NULL, kCFNumberIntType, &key);
     cfvalue = CFDictionaryGetValue(cfdict, cfkey);
@@ -33,6 +34,49 @@ int main (void)
     if (cfvalue) {
       CFNumberGetValue(cfvalue, kCFNumberIntType, &value);
       PASS_CF(value == i, "CFDictionaryGetValue returns correct value %d == %d for key %d", value, i, key);
+    }
+    CFRelease(cfkey);
+  }
+  
+  PASS_CF(CFDictionaryGetCount(cfdict) == count, "CFDictionaryGetCount returns correct value");
+  
+  CFDictionaryRemoveAllValues(cfdict);
+  PASS_CF(CFDictionaryGetCount(cfdict) == 0, "CFDictionaryRemoveAllValues removes all values");
+  
+  // test large dictionary
+  
+  count = 5000;
+  removeCount = 0;
+
+  CFStringRef keyFormat = CFSTR("key-%d");
+
+  for (i = 0; i < count; i++) {
+    
+    cfkey = CFStringCreateWithFormat(NULL, NULL, keyFormat, i);
+    cfvalue = CFNumberCreate(NULL, kCFNumberIntType, &i);
+    CFDictionarySetValue(cfdict, cfkey, cfvalue);
+    CFRelease(cfkey);
+    CFRelease(cfvalue);
+
+    // start removing keys while we are adding new ones after filling 1/10
+    if (i > count/10) {
+      int keyToRemove = removeCount++;
+      cfkey = CFStringCreateWithFormat(NULL, NULL, keyFormat, keyToRemove);
+      cfvalue = CFDictionaryGetValue(cfdict, cfkey);
+      PASS_CF(cfvalue != NULL, "CFDictionaryGetValue returns value for key 'key-%d' to remove", keyToRemove);
+      CFDictionaryRemoveValue(cfdict, cfkey);
+      CFRelease(cfkey);
+    }
+  }
+  
+  for (i = 0; i < count; i++) {
+    cfkey = CFStringCreateWithFormat(NULL, NULL, keyFormat, i);
+    cfvalue = CFDictionaryGetValue(cfdict, cfkey);
+    if (i < removeCount) {
+      PASS_CF(cfvalue == NULL, "CFDictionaryGetValue returns no value for non-existant key 'key-%d': %p", i, cfvalue);
+    } else {
+      CFNumberRef cfvalue2 = CFNumberCreate(NULL, kCFNumberIntType, &i);
+      PASS_CFEQ(cfvalue, cfvalue2, "CFDictionaryGetValue returns correct value for existant key 'key-%d': %p", i, cfvalue);
     }
     CFRelease(cfkey);
   }


### PR DESCRIPTION
This adds additional tests for CFDictionary, which create a dictionary with 5000 items (using CF- and NS-objects respectively), and removing objects while adding new ones.

This exposes what seems like a bug in GSHashTable, as checking the dictionary afterwards will return values for keys that have previously been removed (both for CF- and NS-objects):

[Test Output.txt](https://github.com/gnustep/libs-corebase/files/4892613/Test.Output.txt)

I haven’t yet dug deeper into GSHashTable to find a possible cause, but I hope to do so in the next days. In the meantime I’d appreciate any thoughts or feedback on possible causes or avenues to debug.

On a side note, I noticed that increasing the dictionary size above ~7600 items causes the run time to spike significantly (only when using CF-objects, not with NS-objects), which seems very strange – I haven’t looked into this further:

- 7600 items: 5.817s
- 7700 items: 44.537s