### PR TITLE
Support building on Windows with Clang MSVC target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ obj
 *.sum
 config.*
 CFBase.h
+Source/GNUmakefile
 *.tmp

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-03-19  Frederik Seiffert <frederik@algoriddim.com>
+	* Source/CFRunLoop.c,
+	* Source/GSPrivate.h,
+	* Source/config.h.in,
+	* configure,
+	* configure: Add support for building without pthread library.
+
 2022-09-12  Frederik Seiffert <frederik@algoriddim.com>
 	* configure.ac,
 	* configure,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2021-03-22  Frederik Seiffert <frederik@algoriddim.com>
+	* Source/CFRunLoop.c,
+	* Source/CFRuntime.c
+	* Source/CFSocket.c
+	* Source/CFStream.c
+	* Source/CFStringEncoding.c
+	* Source/CFURLAccess.c
+	* Source/config.h.in,
+	* configure,
+	* configure: Fixed support for building on Windows.
+	CFRunLoop and directory enumeration in CFURLAccess is currently not
+	implemented on Windows, and Windows-specific implementations of
+	CFSocket, CFStream, and CFURLAccess are largely untested so far.
+
 2021-03-19  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFRunLoop.c,
 	* Source/GSPrivate.h,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
+	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
+
+2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFString.c,
 	* Source/config.h.in,
 	* configure,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
+	* Source/CFString.c,
+	* Source/config.h.in,
+	* configure,
+	* configure: Use unorm2 API instead of deprecated unorm
+
 2021-03-22  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFRunLoop.c,
 	* Source/CFRuntime.c
@@ -19,7 +25,7 @@
 	* configure,
 	* configure: Add support for building without pthread library.
 
-2022-09-12  Frederik Seiffert <frederik@algoriddim.com>
+2022-09-12  Stefan Bidigaray <stefanbidi@gmail.com>
 	* configure.ac,
 	* configure,
 	* Source/GNUmakefile: Add ICU_CFLAGS and ICU_LIBS to CFLAGS and LIBS,

--- a/Source/CFCalendar.c
+++ b/Source/CFCalendar.c
@@ -33,7 +33,12 @@
 #include "CoreFoundation/CFRuntime.h"
 #include "GSPrivate.h"
 
+#if defined(HAVE_UNICODE_UCAL_H)
 #include <unicode/ucal.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 struct __CFCalendar
 {

--- a/Source/CFCharacterSet.c
+++ b/Source/CFCharacterSet.c
@@ -30,7 +30,12 @@
 #include "CoreFoundation/CFString.h"
 #include "GSPrivate.h"
 
+#if defined(HAVE_UNICODE_USET_H)
 #include <unicode/uset.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 struct __CFCharacterSet
 {

--- a/Source/CFDate.c
+++ b/Source/CFDate.c
@@ -357,19 +357,18 @@ CFGregorianDateIsValid (CFGregorianDate gdate, CFOptionFlags unitFlags)
   /* unitFlags is unused, must be ignored */
   Boolean isValid = FALSE;
   
-  if (unitFlags | kCFGregorianUnitsYears)
+  if ((unitFlags & kCFGregorianUnitsYears) != 0)
     isValid = TRUE; /* FIXME: What's the test here? */
-  if (unitFlags | kCFGregorianUnitsMonths)
+  if ((unitFlags & kCFGregorianUnitsMonths) != 0)
     isValid = ((gdate.month >= 1) && (gdate.month <= 12));
-  if (unitFlags | kCFGregorianUnitsDays)
+  if ((unitFlags & kCFGregorianUnitsDays) != 0)
     isValid = TRUE; /* FIXME */
-  if (unitFlags | kCFGregorianUnitsHours)
+  if ((unitFlags & kCFGregorianUnitsHours) != 0)
     isValid = ((gdate.hour >= 0) && (gdate.hour < 24));
-  if (unitFlags | kCFGregorianUnitsMinutes)
+  if ((unitFlags & kCFGregorianUnitsMinutes) != 0)
     isValid = ((gdate.minute >= 0) && (gdate.minute < 60));
-  if (unitFlags | kCFGregorianUnitsSeconds)
+  if ((unitFlags & kCFGregorianUnitsSeconds) != 0)
     isValid = ((gdate.second >= 0.0) && (gdate.second < 60.0));
   
   return isValid;
 }
-

--- a/Source/CFDate.c
+++ b/Source/CFDate.c
@@ -33,7 +33,13 @@
 #include "GSObjCRuntime.h"
 
 #include <math.h>
+
+#if defined(HAVE_UNICODE_UCAL_H)
 #include <unicode/ucal.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 static CFTypeID _kCFDateTypeID = 0;
 

--- a/Source/CFDateFormatter.c
+++ b/Source/CFDateFormatter.c
@@ -33,8 +33,15 @@
 #include "CoreFoundation/CFDateFormatter.h"
 #include "GSPrivate.h"
 
+#if defined(HAVE_UNICODE_UDAT_H)
 #include <unicode/udat.h>
+#endif
+#if defined(HAVE_UNICODE_UDATPG_H)
 #include <unicode/udatpg.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 #define BUFFER_SIZE 256
 

--- a/Source/CFLocale.c
+++ b/Source/CFLocale.c
@@ -35,9 +35,19 @@
 #include "GSObjCRuntime.h"
 
 #include <string.h>
+
+#if defined(HAVE_UNICODE_ULOC_H)
 #include <unicode/uloc.h>
+#endif
+#if defined(HAVE_UNICODE_ULOCDATA_H)
 #include <unicode/ulocdata.h>
+#endif
+#if defined(HAVE_UNICODE_UCURR_H)
 #include <unicode/ucurr.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 #define BUFFER_SIZE 256
 

--- a/Source/CFNumberFormatter.c
+++ b/Source/CFNumberFormatter.c
@@ -32,8 +32,15 @@
 
 #include "CoreFoundation/CFNumberFormatter.h"
 
+#if defined(HAVE_UNICODE_UCURR_H)
 #include <unicode/ucurr.h>
+#endif
+#if defined(HAVE_UNICODE_UNUM_H)
 #include <unicode/unum.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 #define BUFFER_SIZE 512
 

--- a/Source/CFRuntime.c
+++ b/Source/CFRuntime.c
@@ -545,7 +545,7 @@ CFInitialize (void)
 #if defined(_MSC_VER)
 #include <windows.h>
 
-BOOL
+WinBOOL
 DllMain (HINSTANCE hinst, DWORD fdwReason, LPVOID ldvReserved)
 {
   if (fdwReason == DLL_PROCESS_ATTACH)

--- a/Source/CFString.c
+++ b/Source/CFString.c
@@ -46,8 +46,6 @@
 
 #if defined(HAVE_UNICODE_UNORM2_H)
 #include <unicode/unorm2.h>
-#elif defined(HAVE_UNICODE_UNORM_H)
-#include <unicode/unorm.h>
 #endif
 #if defined(HAVE_UNICODE_USTRING_H)
 #include <unicode/ustring.h>
@@ -1646,7 +1644,6 @@ CFStringFold (CFMutableStringRef str, CFOptionFlags flags, CFLocaleRef locale)
     CFStringCaseMap (str, locale, flags, _kCFStringFold);
 }
 
-#ifdef __UNORM2_H__
 CF_INLINE const UNormalizer2 *
 CFToICUNormalizer (CFStringNormalizationForm form, UErrorCode *err)
 {
@@ -1664,35 +1661,11 @@ CFToICUNormalizer (CFStringNormalizationForm form, UErrorCode *err)
       return NULL;
     }
 }
-#else
-CF_INLINE UNormalizationMode
-CFToICUNormalization (CFStringNormalizationForm form)
-{
-  switch (form)
-    {
-    case kCFStringNormalizationFormD:
-      return UNORM_NFD;
-    case kCFStringNormalizationFormKD:
-      return UNORM_NFKD;
-    case kCFStringNormalizationFormC:
-      return UNORM_NFC;
-    case kCFStringNormalizationFormKC:
-      return UNORM_NFKC;
-    default:
-      return 1;
-    }
-}
-#endif
 
 void
 CFStringNormalize (CFMutableStringRef str, CFStringNormalizationForm theForm)
 {
 #if !UCONFIG_NO_NORMALIZATION
-  /* FIXME: The unorm API has been officially deprecated on ICU 4.8, however,
-     the new unorm2 API was only introduced on ICU 4.4.  The current plan is
-     to provide compatibility down to ICU 4.0, so unorm is used here.  In
-     the future, when we no longer support building with older versions of
-     the library this code can be updated for the new API. */
   UniChar *oldContents;
   CFIndex oldContentsLength;
   CFIndex newLength;
@@ -1700,13 +1673,9 @@ CFStringNormalize (CFMutableStringRef str, CFStringNormalizationForm theForm)
   UErrorCode err = U_ZERO_ERROR;
   struct __CFMutableString *mStr;
   CFMutableStringRef objc = NULL;
-#ifdef __UNORM2_H__
   const UNormalizer2 *n2 = CFToICUNormalizer (theForm, &err);
   if (n2 == NULL || U_FAILURE (err))
     return;
-#else
-  UNormalizationMode mode = CFToICUNormalization (theForm);
-#endif
 
   /* Make sure string isn't already normalized.  Use the quick check for
      speed. We still go through the normalization if the quick check does not
@@ -1716,13 +1685,8 @@ CFStringNormalize (CFMutableStringRef str, CFStringNormalizationForm theForm)
 
   if (oldContents != NULL)
     {
-#ifdef __UNORM2_H__
       checkResult =
         unorm2_quickCheck (n2, oldContents, oldContentsLength, &err);
-#else
-      checkResult =
-        unorm_quickCheck (oldContents, oldContentsLength, mode, &err);
-#endif
       if (U_FAILURE (err) || checkResult == UNORM_YES)
         return;
     }
@@ -1743,13 +1707,8 @@ CFStringNormalize (CFMutableStringRef str, CFStringNormalizationForm theForm)
   /* Works just like CFStringCaseMap() above... */
   do
     {
-#ifdef __UNORM2_H__
       newLength = unorm2_normalize (n2, oldContents, oldContentsLength,
                                     mStr->_contents, mStr->_capacity, &err);
-#else
-      newLength = unorm_normalize (oldContents, oldContentsLength, mode,
-                                   0, mStr->_contents, mStr->_capacity, &err);
-#endif
     }
   while (err == U_BUFFER_OVERFLOW_ERROR
          && CFStringCheckCapacityAndGrow (str, newLength, NULL));

--- a/Source/CFStringEncoding.c
+++ b/Source/CFStringEncoding.c
@@ -36,8 +36,11 @@
 #include <strings.h>
 #endif
 
-#if HAVE_UNICODE_UCNV_H
+#if defined(HAVE_UNICODE_UCNV_H)
 #include <unicode/ucnv.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
 #endif
 
 static GSMutex _kCFStringEncodingLock;

--- a/Source/CFStringEncoding.c
+++ b/Source/CFStringEncoding.c
@@ -32,7 +32,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <strings.h>
+#endif
 
 #if HAVE_UNICODE_UCNV_H
 #include <unicode/ucnv.h>

--- a/Source/CFStringUtilities.c
+++ b/Source/CFStringUtilities.c
@@ -31,9 +31,18 @@
 #include "CoreFoundation/CFString.h"
 #include "GSPrivate.h"
 
+#if defined(HAVE_UNICODE_UCOL_H)
 #include <unicode/ucol.h>
+#endif
+#if defined(HAVE_UNICODE_ULOC_H)
 #include <unicode/uloc.h>
+#endif
+#if defined(HAVE_UNICODE_USEARCH_H)
 #include <unicode/usearch.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 
 

--- a/Source/CFTimeZone.c
+++ b/Source/CFTimeZone.c
@@ -42,7 +42,13 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#if defined(HAVE_UNICODE_UCAL_H)
 #include <unicode/ucal.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 struct _ttinfo
 {

--- a/Source/GSPrivate.h
+++ b/Source/GSPrivate.h
@@ -48,6 +48,10 @@
 #define ABSOLUTETIME_TO_UDATE(at) \
   (((at) + kCFAbsoluteTimeIntervalSince1970) * 1000.0)
 
+#ifdef HAVE_PTHREAD_H  
+#include <pthread.h>
+#endif
+
 #if defined(_WIN32)
 
 #include <windows.h>
@@ -79,8 +83,6 @@
   InterlockedCompareExchangePointer((ptr), (newv), (oldv))
 
 #else /* _WIN32 */
-
-#include <pthread.h>
 
 #define GSMutex pthread_mutex_t
 #define GSMutexInitialize(x) pthread_mutex_init(x, NULL)

--- a/Source/GSUnicode.c
+++ b/Source/GSUnicode.c
@@ -37,7 +37,12 @@
 #include "GSPrivate.h"
 #include "GSMemory.h"
 
+#if defined(HAVE_UNICODE_UCNV_H)
 #include <unicode/ucnv.h>
+#endif
+#if defined(HAVE_ICU_H)
+#include <icu.h>
+#endif
 
 #define BUFFER_SIZE 512
 

--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -108,6 +108,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define to 1 if you have the <ws2tcpip.h> header file. */
+#undef HAVE_WS2TCPIP_H
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -103,8 +103,8 @@
 /* Define to 1 if you have the <unicode/uloc.h> header file. */
 #undef HAVE_UNICODE_ULOC_H
 
-/* Define to 1 if you have the <unicode/unorm.h> header file. */
-#undef HAVE_UNICODE_UNORM_H
+/* Define to 1 if you have the <unicode/unorm2.h> header file. */
+#undef HAVE_UNICODE_UNORM2_H
 
 /* Define to 1 if you have the <unicode/unum.h> header file. */
 #undef HAVE_UNICODE_UNUM_H

--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -18,8 +18,15 @@
 /* Define LP64 data model. */
 #define DATA_MODEL_LP64 124888
 
+/* Define to 1 if the required libraries and headers for CFRunLoop are
+   present. */
+#undef HAVE_CFRUNLOOP_SUPPORT
+
 /* Define to 1 if you have the <dispatch/dispatch.h> header file. */
 #undef HAVE_DISPATCH_DISPATCH_H
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#undef HAVE_FCNTL_H
 
 /* Define to 1 if you have International Components for Unicode. */
 #undef HAVE_ICU
@@ -36,14 +43,17 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
+/* Define to 1 if you have the <limits.h> header file. */
+#undef HAVE_LIMITS_H
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
 /* Define to 1 if you have the <objc/runtime.h> header file. */
 #undef HAVE_OBJC_RUNTIME_H
 
-/* Define to 1 if you have the pthread library. */
-#undef HAVE_PTHREAD
+/* Define to 1 if you have the <poll.h> header file. */
+#undef HAVE_POLL_H
 
 /* Define to 1 if you have the <pthread.h> header file. */
 #undef HAVE_PTHREAD_H

--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -39,6 +39,12 @@
 /* Define to 1 if you have the <objc/runtime.h> header file. */
 #undef HAVE_OBJC_RUNTIME_H
 
+/* Define to 1 if you have the pthread library. */
+#undef HAVE_PTHREAD
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#undef HAVE_PTHREAD_H
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 

--- a/Source/config.h.in
+++ b/Source/config.h.in
@@ -24,6 +24,9 @@
 /* Define to 1 if you have International Components for Unicode. */
 #undef HAVE_ICU
 
+/* Define to 1 if you have the <icu.h> header file. */
+#undef HAVE_ICU_H
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
@@ -98,6 +101,9 @@
 
 /* Define to 1 if you have the <unicode/usearch.h> header file. */
 #undef HAVE_UNICODE_USEARCH_H
+
+/* Define to 1 if you have the <unicode/uset.h> header file. */
+#undef HAVE_UNICODE_USET_H
 
 /* Define to 1 if you have the <unicode/ustring.h> header file. */
 #undef HAVE_UNICODE_USTRING_H

--- a/Tests/CFTesting.h
+++ b/Tests/CFTesting.h
@@ -4,6 +4,13 @@
 
 #define CFTEST_BUFFER_SIZE 1024
 
+#if defined(__OBJC__) && defined(__clang__) && defined(_MSC_VER)
+/* Work around Clang bug on Windows MSVC when tests contain no
+ * Objective-C constructs: https://bugs.llvm.org/show_bug.cgi?id=49681
+ */
+id __work_around_clang_bug = @"__unused__";
+#endif
+
 static Boolean testPassed = true;
 static Boolean testHopeful = false;
 

--- a/configure
+++ b/configure
@@ -653,6 +653,18 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+target_os
+target_vendor
+target_cpu
+target
+host_os
+host_vendor
+host_cpu
+host
+build_os
+build_vendor
+build_cpu
+build
 target_alias
 host_alias
 build_alias
@@ -1312,6 +1324,11 @@ Fine tuning of the installation directories:
 _ACEOF
 
   cat <<\_ACEOF
+
+System types:
+  --build=BUILD     configure for building on BUILD [guessed]
+  --host=HOST       cross-compile to build programs to run on HOST [BUILD]
+  --target=TARGET   configure for building compilers for TARGET [HOST]
 _ACEOF
 fi
 
@@ -2298,6 +2315,155 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 ac_config_headers="$ac_config_headers Source/config.h"
 
+
+if test -n "$GNUSTEP_MAKEFILES"; then
+  #--------------------------------------------------------------------
+  # Use config.guess, config.sub and install-sh provided by gnustep-make
+  #--------------------------------------------------------------------
+  ac_aux_dir=
+for ac_dir in $GNUSTEP_MAKEFILES "$srcdir"/$GNUSTEP_MAKEFILES; do
+  if test -f "$ac_dir/install-sh"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/install-sh -c"
+    break
+  elif test -f "$ac_dir/install.sh"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/install.sh -c"
+    break
+  elif test -f "$ac_dir/shtool"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/shtool install -c"
+    break
+  fi
+done
+if test -z "$ac_aux_dir"; then
+  as_fn_error $? "cannot find install-sh, install.sh, or shtool in $GNUSTEP_MAKEFILES \"$srcdir\"/$GNUSTEP_MAKEFILES" "$LINENO" 5
+fi
+
+# These three variables are undocumented and unsupported,
+# and are intended to be withdrawn in a future Autoconf release.
+# They can cause serious problems if a builder's source tree is in a directory
+# whose full name contains unusual characters.
+ac_config_guess="$SHELL $ac_aux_dir/config.guess"  # Please don't use this var.
+ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
+ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
+
+
+
+  #--------------------------------------------------------------------
+  # Determine the host, build, and target systems
+  #--------------------------------------------------------------------
+  # Make sure we can run config.sub.
+$SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
+  as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
+$as_echo_n "checking build system type... " >&6; }
+if ${ac_cv_build+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_build_alias=$build_alias
+test "x$ac_build_alias" = x &&
+  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
+test "x$ac_build_alias" = x &&
+  as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
+ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
+  as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
+$as_echo "$ac_cv_build" >&6; }
+case $ac_cv_build in
+*-*-*) ;;
+*) as_fn_error $? "invalid value of canonical build" "$LINENO" 5;;
+esac
+build=$ac_cv_build
+ac_save_IFS=$IFS; IFS='-'
+set x $ac_cv_build
+shift
+build_cpu=$1
+build_vendor=$2
+shift; shift
+# Remember, the first character of IFS is used to create $*,
+# except with old shells:
+build_os=$*
+IFS=$ac_save_IFS
+case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
+$as_echo_n "checking host system type... " >&6; }
+if ${ac_cv_host+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "x$host_alias" = x; then
+  ac_cv_host=$ac_cv_build
+else
+  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
+    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
+$as_echo "$ac_cv_host" >&6; }
+case $ac_cv_host in
+*-*-*) ;;
+*) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
+esac
+host=$ac_cv_host
+ac_save_IFS=$IFS; IFS='-'
+set x $ac_cv_host
+shift
+host_cpu=$1
+host_vendor=$2
+shift; shift
+# Remember, the first character of IFS is used to create $*,
+# except with old shells:
+host_os=$*
+IFS=$ac_save_IFS
+case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
+$as_echo_n "checking target system type... " >&6; }
+if ${ac_cv_target+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "x$target_alias" = x; then
+  ac_cv_target=$ac_cv_host
+else
+  ac_cv_target=`$SHELL "$ac_aux_dir/config.sub" $target_alias` ||
+    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $target_alias failed" "$LINENO" 5
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_target" >&5
+$as_echo "$ac_cv_target" >&6; }
+case $ac_cv_target in
+*-*-*) ;;
+*) as_fn_error $? "invalid value of canonical target" "$LINENO" 5;;
+esac
+target=$ac_cv_target
+ac_save_IFS=$IFS; IFS='-'
+set x $ac_cv_target
+shift
+target_cpu=$1
+target_vendor=$2
+shift; shift
+# Remember, the first character of IFS is used to create $*,
+# except with old shells:
+target_os=$*
+IFS=$ac_save_IFS
+case $target_os in *\ *) target_os=`echo "$target_os" | sed 's/ /-/g'`;; esac
+
+
+# The aliases save the names the user supplied, while $host etc.
+# will get canonicalized.
+test -n "$target_alias" &&
+  test "$program_prefix$program_suffix$program_transform_name" = \
+    NONENONEs,x,x, &&
+  program_prefix=${target_alias}-
+fi
 
 #--------------------------------------------------------------------
 # Find the compiler
@@ -4902,7 +5068,7 @@ _ACEOF
 
 
 #--------------------------------------------------------------------
-# Check for pthread.h
+# Check for pthread.h (not needed on Windows)
 #--------------------------------------------------------------------
 for ac_header in pthread.h
 do :
@@ -4917,7 +5083,15 @@ fi
 done
 
 if test $ac_cv_header_pthread_h = no ; then
-  as_fn_error $? "Unable to find pthread.h (needed for thread support)." "$LINENO" 5
+  # pthread is optional on Windows (for CFRunLoop), but required on all
+  # other platforms.
+  case "$target_os" in
+    mingw*|windows)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to find pthread.h (needed for thread support)" >&5
+$as_echo "$as_me: WARNING: Unable to find pthread.h (needed for thread support)" >&2;};;
+    *)
+      as_fn_error $? "Unable to find pthread.h (needed for thread support)" "$LINENO" 5;;
+  esac
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthread" >&5
 $as_echo_n "checking for pthread_join in -lpthread... " >&6; }
@@ -4961,18 +5135,10 @@ else
   pthread_ok=no
 fi
 
-ismingw=no
-checkinlibc=no
-case "$target_os" in
-  mingw*)	ismingw=yes;;
-  windows) iswindows=yes;;
-  nto*)		checkinlibc=yes;;
-  qnx*)		checkinlibc=yes;;
-  *android*)   checkinlibc=yes;;
-esac
 if test $pthread_ok = no ; then
-  if test $ismingw = yes ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadGC2" >&5
+  case "$target_os" in
+    mingw*)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadGC2" >&5
 $as_echo_n "checking for pthread_join in -lpthreadGC2... " >&6; }
 if ${ac_cv_lib_pthreadGC2_pthread_join+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5014,9 +5180,9 @@ else
   pthread_ok=no
 fi
 
-  fi
-  if test $iswindows = yes ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadVC2" >&5
+      ;;
+    windows)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadVC2" >&5
 $as_echo_n "checking for pthread_join in -lpthreadVC2... " >&6; }
 if ${ac_cv_lib_pthreadVC2_pthread_join+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5058,10 +5224,10 @@ else
   pthread_ok=no
 fi
 
-  fi
-  # Android and QNX have pthread in libc instead of libpthread
-  if test $checkinlibc = yes ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lc" >&5
+      ;;
+    nto*|qnx*|*android*)
+      # Android and QNX have pthread in libc instead of libpthread
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lc" >&5
 $as_echo_n "checking for pthread_join in -lc... " >&6; }
 if ${ac_cv_lib_c_pthread_join+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5103,7 +5269,8 @@ else
   pthread_ok=no
 fi
 
-  fi
+      ;;
+  esac
 fi
 if test $pthread_ok = yes ; then
 

--- a/configure
+++ b/configure
@@ -672,7 +672,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -754,7 +753,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1007,15 +1005,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1153,7 +1142,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1306,7 +1295,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/configure
+++ b/configure
@@ -4900,6 +4900,217 @@ _ACEOF
 
 
 
+
+#--------------------------------------------------------------------
+# Check for pthread.h
+#--------------------------------------------------------------------
+for ac_header in pthread.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
+if test "x$ac_cv_header_pthread_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_PTHREAD_H 1
+_ACEOF
+
+fi
+
+done
+
+if test $ac_cv_header_pthread_h = no ; then
+  as_fn_error $? "Unable to find pthread.h (needed for thread support)." "$LINENO" 5
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthread" >&5
+$as_echo_n "checking for pthread_join in -lpthread... " >&6; }
+if ${ac_cv_lib_pthread_pthread_join+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpthread  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join ();
+int
+main ()
+{
+return pthread_join ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pthread_pthread_join=yes
+else
+  ac_cv_lib_pthread_pthread_join=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_join" >&5
+$as_echo "$ac_cv_lib_pthread_pthread_join" >&6; }
+if test "x$ac_cv_lib_pthread_pthread_join" = xyes; then :
+  pthread_ok=yes
+else
+  pthread_ok=no
+fi
+
+ismingw=no
+checkinlibc=no
+case "$target_os" in
+  mingw*)	ismingw=yes;;
+  windows) iswindows=yes;;
+  nto*)		checkinlibc=yes;;
+  qnx*)		checkinlibc=yes;;
+  *android*)   checkinlibc=yes;;
+esac
+if test $pthread_ok = no ; then
+  if test $ismingw = yes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadGC2" >&5
+$as_echo_n "checking for pthread_join in -lpthreadGC2... " >&6; }
+if ${ac_cv_lib_pthreadGC2_pthread_join+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpthreadGC2  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join ();
+int
+main ()
+{
+return pthread_join ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pthreadGC2_pthread_join=yes
+else
+  ac_cv_lib_pthreadGC2_pthread_join=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthreadGC2_pthread_join" >&5
+$as_echo "$ac_cv_lib_pthreadGC2_pthread_join" >&6; }
+if test "x$ac_cv_lib_pthreadGC2_pthread_join" = xyes; then :
+  pthread_ok=yes
+else
+  pthread_ok=no
+fi
+
+  fi
+  if test $iswindows = yes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadVC2" >&5
+$as_echo_n "checking for pthread_join in -lpthreadVC2... " >&6; }
+if ${ac_cv_lib_pthreadVC2_pthread_join+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpthreadVC2  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join ();
+int
+main ()
+{
+return pthread_join ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pthreadVC2_pthread_join=yes
+else
+  ac_cv_lib_pthreadVC2_pthread_join=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthreadVC2_pthread_join" >&5
+$as_echo "$ac_cv_lib_pthreadVC2_pthread_join" >&6; }
+if test "x$ac_cv_lib_pthreadVC2_pthread_join" = xyes; then :
+  pthread_ok=yes
+else
+  pthread_ok=no
+fi
+
+  fi
+  # Android and QNX have pthread in libc instead of libpthread
+  if test $checkinlibc = yes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lc" >&5
+$as_echo_n "checking for pthread_join in -lc... " >&6; }
+if ${ac_cv_lib_c_pthread_join+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lc  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join ();
+int
+main ()
+{
+return pthread_join ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_c_pthread_join=yes
+else
+  ac_cv_lib_c_pthread_join=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_pthread_join" >&5
+$as_echo "$ac_cv_lib_c_pthread_join" >&6; }
+if test "x$ac_cv_lib_c_pthread_join" = xyes; then :
+  pthread_ok=yes
+else
+  pthread_ok=no
+fi
+
+  fi
+fi
+if test $pthread_ok = yes ; then
+
+$as_echo "#define HAVE_PTHREAD 1" >>confdefs.h
+
+fi
+
 #---
 # Check for ICU
 #---

--- a/configure
+++ b/configure
@@ -5602,6 +5602,22 @@ _ACEOF
 fi
 
 
+#---
+# Check for WinSock2
+#---
+for ac_header in ws2tcpip.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "ws2tcpip.h" "ac_cv_header_ws2tcpip_h" "$ac_includes_default"
+if test "x$ac_cv_header_ws2tcpip_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_WS2TCPIP_H 1
+_ACEOF
+
+fi
+
+done
+
+
 ac_config_files="$ac_config_files Source/GNUmakefile Headers/CoreFoundation/CFBase.h"
 
 

--- a/configure
+++ b/configure
@@ -5446,7 +5446,7 @@ else
 $as_echo "yes" >&6; }
 
 fi
-    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
+    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"; INCLUDE_FLAGS="$INCLUDE_FLAGS $ICU_CFLAGS"
     for ac_header in unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm2.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`

--- a/configure
+++ b/configure
@@ -706,6 +706,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_cfrunloop
 with_icu
 with_gcd
 with_objc
@@ -1337,6 +1338,14 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of libgnustep-corebase 0.2:";;
    esac
   cat <<\_ACEOF
+
+Optional Features:
+  --disable-option-checking  ignore unrecognized --enable/--with options
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+--disable-cfrunloop
+    Disables CFRunLoop support and requiring pthread.
+    Must be passed when building on Windows.
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -5068,215 +5077,89 @@ _ACEOF
 
 
 #--------------------------------------------------------------------
-# Check for pthread.h (not needed on Windows)
+# Check for CFRunLoop support
+# Android and QNX have pthread in libc instead of libpthread
 #--------------------------------------------------------------------
-for ac_header in pthread.h
+# Check whether --enable-cfrunloop was given.
+if test "${enable_cfrunloop+set}" = set; then :
+  enableval=$enable_cfrunloop;
+else
+  for ac_header in unistd.h fcntl.h poll.h limits.h pthread.h
 do :
-  ac_fn_c_check_header_mongrel "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
-if test "x$ac_cv_header_pthread_h" = xyes; then :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_PTHREAD_H 1
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
 _ACEOF
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pthread_join" >&5
+$as_echo_n "checking for library containing pthread_join... " >&6; }
+if ${ac_cv_search_pthread_join+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pthread_join ();
+int
+main ()
+{
+return pthread_join ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' pthread pthreadG32 pthreadVC2; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_pthread_join=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_pthread_join+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_pthread_join+:} false; then :
+
+else
+  ac_cv_search_pthread_join=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_pthread_join" >&5
+$as_echo "$ac_cv_search_pthread_join" >&6; }
+ac_res=$ac_cv_search_pthread_join
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+$as_echo "#define HAVE_CFRUNLOOP_SUPPORT 1" >>confdefs.h
+
+else
+  as_fn_error $? "Missing pthread library for CFRunLoop support." "$LINENO" 5
+fi
+
+else
+  as_fn_error $? "Missing headers for CFRunLoop support." "$LINENO" 5
 fi
 
 done
 
-if test $ac_cv_header_pthread_h = no ; then
-  # pthread is optional on Windows (for CFRunLoop), but required on all
-  # other platforms.
-  case "$target_os" in
-    mingw*|windows)
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to find pthread.h (needed for thread support)" >&5
-$as_echo "$as_me: WARNING: Unable to find pthread.h (needed for thread support)" >&2;};;
-    *)
-      as_fn_error $? "Unable to find pthread.h (needed for thread support)" "$LINENO" 5;;
-  esac
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthread" >&5
-$as_echo_n "checking for pthread_join in -lpthread... " >&6; }
-if ${ac_cv_lib_pthread_pthread_join+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpthread  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char pthread_join ();
-int
-main ()
-{
-return pthread_join ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_pthread_pthread_join=yes
-else
-  ac_cv_lib_pthread_pthread_join=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_join" >&5
-$as_echo "$ac_cv_lib_pthread_pthread_join" >&6; }
-if test "x$ac_cv_lib_pthread_pthread_join" = xyes; then :
-  pthread_ok=yes
-else
-  pthread_ok=no
 fi
 
-if test $pthread_ok = no ; then
-  case "$target_os" in
-    mingw*)
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadGC2" >&5
-$as_echo_n "checking for pthread_join in -lpthreadGC2... " >&6; }
-if ${ac_cv_lib_pthreadGC2_pthread_join+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpthreadGC2  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char pthread_join ();
-int
-main ()
-{
-return pthread_join ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_pthreadGC2_pthread_join=yes
-else
-  ac_cv_lib_pthreadGC2_pthread_join=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthreadGC2_pthread_join" >&5
-$as_echo "$ac_cv_lib_pthreadGC2_pthread_join" >&6; }
-if test "x$ac_cv_lib_pthreadGC2_pthread_join" = xyes; then :
-  pthread_ok=yes
-else
-  pthread_ok=no
-fi
-
-      ;;
-    windows)
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lpthreadVC2" >&5
-$as_echo_n "checking for pthread_join in -lpthreadVC2... " >&6; }
-if ${ac_cv_lib_pthreadVC2_pthread_join+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpthreadVC2  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char pthread_join ();
-int
-main ()
-{
-return pthread_join ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_pthreadVC2_pthread_join=yes
-else
-  ac_cv_lib_pthreadVC2_pthread_join=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthreadVC2_pthread_join" >&5
-$as_echo "$ac_cv_lib_pthreadVC2_pthread_join" >&6; }
-if test "x$ac_cv_lib_pthreadVC2_pthread_join" = xyes; then :
-  pthread_ok=yes
-else
-  pthread_ok=no
-fi
-
-      ;;
-    nto*|qnx*|*android*)
-      # Android and QNX have pthread in libc instead of libpthread
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in -lc" >&5
-$as_echo_n "checking for pthread_join in -lc... " >&6; }
-if ${ac_cv_lib_c_pthread_join+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char pthread_join ();
-int
-main ()
-{
-return pthread_join ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_pthread_join=yes
-else
-  ac_cv_lib_c_pthread_join=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_pthread_join" >&5
-$as_echo "$ac_cv_lib_c_pthread_join" >&6; }
-if test "x$ac_cv_lib_c_pthread_join" = xyes; then :
-  pthread_ok=yes
-else
-  pthread_ok=no
-fi
-
-      ;;
-  esac
-fi
-if test $pthread_ok = yes ; then
-
-$as_echo "#define HAVE_PTHREAD 1" >>confdefs.h
-
-fi
 
 #---
 # Check for ICU

--- a/configure
+++ b/configure
@@ -5447,7 +5447,7 @@ $as_echo "yes" >&6; }
 
 fi
     LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
-    for ac_header in unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h
+    for ac_header in unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm2.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure
+++ b/configure
@@ -5410,6 +5410,68 @@ $as_echo "no" >&6; }
 	fi
 fi
 if test x"with_icu" != xno; then :
+  found_icu=no
+  case $target_os in #(
+  mingw*|windows) :
+     # check for ICU bundled with Windows 10
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for udat_open in -licu" >&5
+$as_echo_n "checking for udat_open in -licu... " >&6; }
+if ${ac_cv_lib_icu_udat_open+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-licu  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char udat_open ();
+int
+main ()
+{
+return udat_open ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_icu_udat_open=yes
+else
+  ac_cv_lib_icu_udat_open=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_icu_udat_open" >&5
+$as_echo "$ac_cv_lib_icu_udat_open" >&6; }
+if test "x$ac_cv_lib_icu_udat_open" = xyes; then :
+  for ac_header in icu.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "icu.h" "ac_cv_header_icu_h" "$ac_includes_default"
+if test "x$ac_cv_header_icu_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_ICU_H 1
+_ACEOF
+ found_icu=yes
+          LIBS="$LIBS -licu"
+          { $as_echo "$as_me:${as_lineno-$LINENO}: Using ICU DLL from Windows 10 (requires version 1903)" >&5
+$as_echo "$as_me: Using ICU DLL from Windows 10 (requires version 1903)" >&6;}
+fi
+
+done
+
+fi
+ ;; #(
+  *) :
+     ;;
+esac
+  if test $found_icu = no; then :
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for icu-i18n > 49.0" >&5
@@ -5499,9 +5561,10 @@ else
 	ICU_LIBS=$pkg_cv_ICU_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
+
 fi
-  for ac_header in unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/ustring.h unicode/utrans.h
+    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
+    for ac_header in unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -5516,9 +5579,9 @@ fi
 
 done
 
+fi
 
 $as_echo "#define HAVE_ICU 1" >>confdefs.h
-
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,41 @@ AS_CASE([$gs_cv_c_data_model],
 AC_CHECK_SIZEOF([double])
 AC_CHECK_SIZEOF([long double])
 
+
+#--------------------------------------------------------------------
+# Check for pthread.h
+#--------------------------------------------------------------------
+AC_CHECK_HEADERS([pthread.h])
+if test $ac_cv_header_pthread_h = no ; then
+  AC_MSG_ERROR([Unable to find pthread.h (needed for thread support).])
+fi
+AC_CHECK_LIB(pthread, pthread_join, pthread_ok=yes, pthread_ok=no)
+ismingw=no
+checkinlibc=no
+case "$target_os" in
+  mingw*)	ismingw=yes;;
+  windows) iswindows=yes;;
+  nto*)		checkinlibc=yes;;
+  qnx*)		checkinlibc=yes;;
+  *android*)   checkinlibc=yes;;
+esac
+if test $pthread_ok = no ; then
+  if test $ismingw = yes ; then
+    AC_CHECK_LIB(pthreadGC2, pthread_join, pthread_ok=yes, pthread_ok=no)
+  fi
+  if test $iswindows = yes ; then
+    AC_CHECK_LIB(pthreadVC2, pthread_join, pthread_ok=yes, pthread_ok=no)
+  fi
+  # Android and QNX have pthread in libc instead of libpthread
+  if test $checkinlibc = yes ; then
+    AC_CHECK_LIB(c, pthread_join, pthread_ok=yes, pthread_ok=no)
+  fi
+fi
+if test $pthread_ok = yes ; then
+  AC_DEFINE([HAVE_PTHREAD], [1],
+    [Define to 1 if you have the pthread library.])
+fi
+
 #---
 # Check for ICU
 #---

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,11 @@ AC_DEFINE_UNQUOTED([TZDIR], ["$with_zoneinfo"],
 #---
 AC_CHECK_LIB(m, modf)
 
+#---
+# Check for WinSock2
+#---
+AC_CHECK_HEADERS(ws2tcpip.h)
+
 AC_CONFIG_FILES([Source/GNUmakefile Headers/CoreFoundation/CFBase.h])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -91,38 +91,20 @@ AC_CHECK_SIZEOF([long double])
 
 
 #--------------------------------------------------------------------
-# Check for pthread.h (not needed on Windows)
+# Check for CFRunLoop support
+# Android and QNX have pthread in libc instead of libpthread
 #--------------------------------------------------------------------
-AC_CHECK_HEADERS([pthread.h])
-if test $ac_cv_header_pthread_h = no ; then
-  # pthread is optional on Windows (for CFRunLoop), but required on all
-  # other platforms.
-  case "$target_os" in
-    mingw*|windows)
-      AC_MSG_WARN([Unable to find pthread.h (needed for thread support)]);;
-    *)
-      AC_MSG_ERROR([Unable to find pthread.h (needed for thread support)]);;
-  esac
-fi
-AC_CHECK_LIB(pthread, pthread_join, pthread_ok=yes, pthread_ok=no)
-if test $pthread_ok = no ; then
-  case "$target_os" in
-    mingw*)
-      AC_CHECK_LIB(pthreadGC2, pthread_join, pthread_ok=yes, pthread_ok=no)
-      ;;
-    windows)
-      AC_CHECK_LIB(pthreadVC2, pthread_join, pthread_ok=yes, pthread_ok=no)
-      ;;
-    nto*|qnx*|*android*)
-      # Android and QNX have pthread in libc instead of libpthread
-      AC_CHECK_LIB(c, pthread_join, pthread_ok=yes, pthread_ok=no)
-      ;;
-  esac
-fi
-if test $pthread_ok = yes ; then
-  AC_DEFINE([HAVE_PTHREAD], [1],
-    [Define to 1 if you have the pthread library.])
-fi
+AC_ARG_ENABLE(cfrunloop,
+  [--disable-cfrunloop
+    Disables CFRunLoop support and requiring pthread.
+    Must be passed when building on Windows.],
+  [],
+  [AC_CHECK_HEADERS([unistd.h fcntl.h poll.h limits.h pthread.h],
+    [AC_SEARCH_LIBS(pthread_join, [pthread pthreadG32 pthreadVC2],
+      [AC_DEFINE(HAVE_CFRUNLOOP_SUPPORT, 1,
+        [Define to 1 if the required libraries and headers for CFRunLoop are present.])],
+      [AC_MSG_ERROR([Missing pthread library for CFRunLoop support.])])],
+    [AC_MSG_ERROR([Missing headers for CFRunLoop support.])])])
 
 #---
 # Check for ICU

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,18 @@ AC_INIT([libgnustep-corebase], [0.2], [bug-gnustep@gnu.org])
 AC_CONFIG_SRCDIR([Source/CFBase.c])
 AC_CONFIG_HEADERS([Source/config.h])
 
+if test -n "$GNUSTEP_MAKEFILES"; then
+  #--------------------------------------------------------------------
+  # Use config.guess, config.sub and install-sh provided by gnustep-make
+  #--------------------------------------------------------------------
+  AC_CONFIG_AUX_DIR($GNUSTEP_MAKEFILES)
+  
+  #--------------------------------------------------------------------
+  # Determine the host, build, and target systems
+  #--------------------------------------------------------------------
+  AC_CANONICAL_TARGET([])
+fi
+
 #--------------------------------------------------------------------
 # Find the compiler
 #--------------------------------------------------------------------
@@ -79,33 +91,33 @@ AC_CHECK_SIZEOF([long double])
 
 
 #--------------------------------------------------------------------
-# Check for pthread.h
+# Check for pthread.h (not needed on Windows)
 #--------------------------------------------------------------------
 AC_CHECK_HEADERS([pthread.h])
 if test $ac_cv_header_pthread_h = no ; then
-  AC_MSG_ERROR([Unable to find pthread.h (needed for thread support).])
+  # pthread is optional on Windows (for CFRunLoop), but required on all
+  # other platforms.
+  case "$target_os" in
+    mingw*|windows)
+      AC_MSG_WARN([Unable to find pthread.h (needed for thread support)]);;
+    *)
+      AC_MSG_ERROR([Unable to find pthread.h (needed for thread support)]);;
+  esac
 fi
 AC_CHECK_LIB(pthread, pthread_join, pthread_ok=yes, pthread_ok=no)
-ismingw=no
-checkinlibc=no
-case "$target_os" in
-  mingw*)	ismingw=yes;;
-  windows) iswindows=yes;;
-  nto*)		checkinlibc=yes;;
-  qnx*)		checkinlibc=yes;;
-  *android*)   checkinlibc=yes;;
-esac
 if test $pthread_ok = no ; then
-  if test $ismingw = yes ; then
-    AC_CHECK_LIB(pthreadGC2, pthread_join, pthread_ok=yes, pthread_ok=no)
-  fi
-  if test $iswindows = yes ; then
-    AC_CHECK_LIB(pthreadVC2, pthread_join, pthread_ok=yes, pthread_ok=no)
-  fi
-  # Android and QNX have pthread in libc instead of libpthread
-  if test $checkinlibc = yes ; then
-    AC_CHECK_LIB(c, pthread_join, pthread_ok=yes, pthread_ok=no)
-  fi
+  case "$target_os" in
+    mingw*)
+      AC_CHECK_LIB(pthreadGC2, pthread_join, pthread_ok=yes, pthread_ok=no)
+      ;;
+    windows)
+      AC_CHECK_LIB(pthreadVC2, pthread_join, pthread_ok=yes, pthread_ok=no)
+      ;;
+    nto*|qnx*|*android*)
+      # Android and QNX have pthread in libc instead of libpthread
+      AC_CHECK_LIB(c, pthread_join, pthread_ok=yes, pthread_ok=no)
+      ;;
+  esac
 fi
 if test $pthread_ok = yes ; then
   AC_DEFINE([HAVE_PTHREAD], [1],

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ AS_IF([test x"with_icu" != xno],
           AC_MSG_NOTICE([Using ICU DLL from Windows 10 (requires version 1903)])])])])
   AS_IF([test $found_icu = no],
     [PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0])
-    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
+    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"; INCLUDE_FLAGS="$INCLUDE_FLAGS $ICU_CFLAGS"
     AC_CHECK_HEADERS([unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm2.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h], [],
       AC_MSG_ERROR([Could not find required ICU headers.]))])
   AC_DEFINE([HAVE_ICU], [1],

--- a/configure.ac
+++ b/configure.ac
@@ -123,8 +123,8 @@ AS_IF([test x"with_icu" != xno],
   AS_IF([test $found_icu = no],
     [PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0])
     LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
-    AC_CHECK_HEADERS([unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h],
-[], AC_MSG_ERROR([Could not find required ICU headers.]))])
+    AC_CHECK_HEADERS([unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm2.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h], [],
+      AC_MSG_ERROR([Could not find required ICU headers.]))])
   AC_DEFINE([HAVE_ICU], [1],
     [Define to 1 if you have International Components for Unicode.])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -131,12 +131,20 @@ AC_ARG_WITH([icu],
   AS_HELP_STRING([--without-icu],
     [Disable Internation Components for Unicode. WARNING: Many components will stop working without ICU support!]), [], [with_icu=yes])
 AS_IF([test x"with_icu" != xno],
-  [PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0], [LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"])
-  AC_CHECK_HEADERS([unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/ustring.h unicode/utrans.h],
-  [], AC_MSG_ERROR([Could not find required ICU headers.]))
+  [found_icu=no
+  AS_CASE([$target_os],
+    [mingw*|windows], [ # check for ICU bundled with Windows 10
+      AC_CHECK_LIB(icu, udat_open,
+        [AC_CHECK_HEADERS([icu.h], [found_icu=yes
+          LIBS="$LIBS -licu"
+          AC_MSG_NOTICE([Using ICU DLL from Windows 10 (requires version 1903)])])])])
+  AS_IF([test $found_icu = no],
+    [PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0])
+    LIBS="$LIBS $ICU_LIBS"; CFLAGS="$CFLAGS $ICU_CFLAGS"
+    AC_CHECK_HEADERS([unicode/ucal.h unicode/uchar.h unicode/ucnv.h unicode/ucol.h unicode/ucurr.h unicode/udat.h unicode/udatpg.h unicode/uloc.h unicode/ulocdata.h unicode/unorm.h unicode/unum.h unicode/usearch.h unicode/uset.h unicode/ustring.h unicode/utrans.h],
+[], AC_MSG_ERROR([Could not find required ICU headers.]))])
   AC_DEFINE([HAVE_ICU], [1],
-    [Define to 1 if you have International Components for Unicode.])
-  ])
+    [Define to 1 if you have International Components for Unicode.])])
 
 #---
 # Check for Grand Central Dispatch (libdispatch)


### PR DESCRIPTION
Various changes to support building on Windows with Clang MSVC target and libobjc2.

The [GNUstep Windows MSVC Toolchain](https://github.com/gnustep/tools-windows-msvc) project has been using my branch with these changes for almost a year, but I’ve only now been able to confirm that the changes don’t cause any additional test failures on Linux.