### PR TITLE
Fix syntax error in configure

### DIFF
--- a/configure
+++ b/configure
@@ -5493,7 +5493,7 @@ if ${ac_cv_lib_dispatch_dispatch_get_main_queue_eventfd_np+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-ldispatch as_fn_error $? "Could not find the Grand Central Dispatch headers." "$LINENO" 5 $LIBS"
+LIBS="-ldispatch as_fn_error $? 'Could not find the Grand Central Dispatch headers.' "$LINENO" 5 $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 


### PR DESCRIPTION
The message in one of the libdispatch checks is surrounded by double quotes "Could not ..."

This terminates the double quotes that are already there, leading to a "not: command not found" error if the code is actually executed.

Changing the quotes for the human readable text to single quotes and leaving the other quotes intact fixes the issues.

I had actually encountered this problem earlier when trying to build on 64 bit PiOS, but it also happened when re-installing on my ubuntu-arm image.
