### PR TITLE
Add CI for libs-corebase

### DIFF
--- a/.github/scripts/dependencies.sh
+++ b/.github/scripts/dependencies.sh
@@ -1,0 +1,85 @@
+#! /usr/bin/env sh
+
+set -ex
+
+install_gnustep_make() {
+    echo "::group::GNUstep Make"
+    cd $DEPS_PATH
+    git clone -q -b ${TOOLS_MAKE_BRANCH:-master} https://github.com/gnustep/tools-make.git
+    cd tools-make
+    MAKE_OPTS=
+    if [ -n "$HOST" ]; then
+      MAKE_OPTS="$MAKE_OPTS --host=$HOST"
+    fi
+    if [ -n "$RUNTIME_VERSION" ]; then
+      MAKE_OPTS="$MAKE_OPTS --with-runtime-abi=$RUNTIME_VERSION"
+    fi
+    ./configure --prefix=$INSTALL_PATH --with-library-combo=$LIBRARY_COMBO $MAKE_OPTS || cat config.log
+    make install
+
+    echo Objective-C build flags:
+    $INSTALL_PATH/bin/gnustep-config --objc-flags
+    echo "::endgroup::"
+}
+
+install_libobjc2() {
+    echo "::group::libobjc2"
+    cd $DEPS_PATH
+    git clone -q https://github.com/gnustep/libobjc2.git
+    cd libobjc2
+    git submodule sync
+    git submodule update --init
+    mkdir build
+    cd build
+    cmake \
+      -DTESTS=off \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DGNUSTEP_INSTALL_TYPE=NONE \
+      -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH \
+      ../
+    make install
+    echo "::endgroup::"
+}
+
+install_libdispatch() {
+    echo "::group::libdispatch"
+    cd $DEPS_PATH
+    git clone -q https://github.com/swiftlang/swift-corelibs-libdispatch.git libdispatch
+    mkdir libdispatch/build
+    cd libdispatch/build
+    # -Wno-error=void-pointer-to-int-cast to work around build error in queue.c due to -Werror
+    cmake \
+      -DBUILD_TESTING=off \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH \
+      -DCMAKE_C_FLAGS="-Wno-error=void-pointer-to-int-cast" \
+      -DINSTALL_PRIVATE_HEADERS=1 \
+      -DBlocksRuntime_INCLUDE_DIR=$INSTALL_PATH/include \
+      -DBlocksRuntime_LIBRARIES=$INSTALL_PATH/lib/libobjc.so \
+      ../
+    make install
+    echo "::endgroup::"
+}
+
+install_gnustep_base() {
+    echo "::group::GNUstep Base"
+    cd $DEPS_PATH
+    . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+    git clone -q -b ${LIBS_BASE_BRANCH:-master} https://github.com/gnustep/libs-base.git
+    cd libs-base
+    ./configure
+    make
+    make install
+    echo "::endgroup::"
+}
+
+mkdir -p $DEPS_PATH
+
+# Windows MSVC toolchain uses tools-windows-msvc scripts to install non-GNUstep dependencies
+if [ "$LIBRARY_COMBO" = "ng-gnu-gnu" -a "$IS_WINDOWS_MSVC" != "true" ]; then
+    install_libobjc2
+    install_libdispatch
+fi
+
+install_gnustep_make
+install_gnustep_base

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -105,4 +105,3 @@ jobs:
           name: Logs - ${{ matrix.name }}
           path: |
             ${{ env.SRC_PATH }}/config.log
-            ${{ env.DEPS_PATH }}/libs-base/config.log

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      tools_make_branch:
+        description: "tools-make branch"
+        default: "master"
+        required: true
+      libs_base_branch:
+        description: "libs-base branch"
+        default: "master"
+        required: true
+
+env:
+  APT_PACKAGES: >-
+    pkg-config
+    libgnutls28-dev
+    libffi-dev
+    libicu-dev
+    libxml2-dev
+    libxslt1-dev
+    libssl-dev
+    libavahi-client-dev
+    zlib1g-dev
+    gnutls-bin
+    libcurl4-gnutls-dev
+    libgmp-dev
+
+  # packages for libobjc2 / libdispatch
+  APT_PACKAGES_clang: >-
+    libpthread-workqueue-dev
+
+jobs:
+  ########### Linux ###########
+  linux:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    # don't run pull requests from local branches twice
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu x64 Clang gnustep-1.9
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-1.9
+            CC: clang
+            CXX: clang++
+
+          - name: Ubuntu x64 Clang gnustep-2.0
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-2.0
+            CC: clang
+            CXX: clang++
+
+    env:
+      SRC_PATH: ${{ github.workspace }}/source
+      DEPS_PATH: ${{ github.workspace }}/dependencies
+      INSTALL_PATH: ${{ github.workspace }}/build
+      CC: ${{ matrix.CC }}
+      CXX: ${{ matrix.CXX }}
+      LIBRARY_COMBO: ${{ matrix.library-combo }}
+      RUNTIME_VERSION: ${{ matrix.runtime-version }}
+
+    defaults:
+      run:
+        working-directory: ${{ env.SRC_PATH }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.SRC_PATH }}
+
+      - name: Install packages
+        run: |
+          sudo apt-get -q -y update
+          sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_clang
+
+          # gnustep-2.0 runtime requires ld.gold or lld
+          if [ "$RUNTIME_VERSION" = "gnustep-2.0" ]; then
+            sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
+          fi
+
+      - name: Install dependencies
+        env:
+          TOOLS_MAKE_BRANCH: ${{github.event.inputs.tools_make_branch}}
+          LIBS_BASE_BRANCH: ${{github.event.inputs.libs_base_branch}}
+        run: ./.github/scripts/dependencies.sh
+
+      - name: Build source
+        run: |
+          . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          ./configure CPPFLAGS="-I$INSTALL_PATH/include" LDFLAGS="-L$INSTALL_PATH/lib"
+          make
+          make install
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Logs - ${{ matrix.name }}
+          path: |
+            ${{ env.SRC_PATH }}/config.log
+            ${{ env.DEPS_PATH }}/libs-base/config.log


### PR DESCRIPTION
I noticed this repo did not have CI after fixing CI for libs-opal earlier.  I was able to reuse most of the same work to make CI for this repo also.   It is modeled after the CI from libs-gui.  

I tried to add GCC also but I have not been able to get GCC working yet with libs-corebase.  I am not sure yet if there is a workaround for that.  

In the meantime this would at least add CI for CLANG and examples of what the runs would look like can be viewed here.

https://github.com/pkgdemon/libs-corebase/actions/runs/24940929034

Not sure who monitors this repo @gcasa @fredkiefer @rfm but just FYI ^^