### PR TITLE
CFURL: size percent-escape buffer for worst-case UTF-8 expansion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-27  DTW-Thalion  <todd.white@thalion.global>
+	* Source/CFURL.c (CFURLCreateStringByAddingPercentEscapes): Size the
+	output buffer for the worst-case percent-escape expansion (3 * MAX_BYTES
+	characters per input character).
+	* Tests/CFURL/escaping.m: Add a non-ASCII escaping test.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFURL.c
+++ b/Source/CFURL.c
@@ -1490,10 +1490,13 @@ CFURLCreateStringByAddingPercentEscapes (CFAllocatorRef alloc,
         {
           if (dst == NULL)
             {
-              dst = CFAllocatorAllocate (alloc, sizeof(char) * sLength * 3, 0);
+              /* Worst case scenario is 3 * MAX_BYTES output chars per input
+                 character (e.g. U+20AC -> "%E2%82%AC") . */
+              dst = CFAllocatorAllocate (alloc,
+                sizeof(char) * sLength * (3 * MAX_BYTES), 0);
               CFStringGetBytes (origString, CFRangeMake(0, idx),
                 kCFStringEncodingASCII, 0, false, (UInt8*)dst,
-                sLength * 3, NULL);
+                sLength * (3 * MAX_BYTES), NULL);
               dpos = dst + idx;
             }
           if (!CFURLAppendPercentEscapedForCharacter (&dpos, c, encoding))

--- a/Tests/CFURL/escaping.m
+++ b/Tests/CFURL/escaping.m
@@ -1,4 +1,5 @@
 #include "CoreFoundation/CFURL.h"
+#include "CoreFoundation/CFString.h"
 
 #include "../CFTesting.h"
 
@@ -39,6 +40,21 @@ int main (void)
   
   CFRelease (str);
   CFRelease (str2);
-  
+
+  /* A non-ASCII character escapes to its multi-byte UTF-8 form: U+20AC ->
+     "%E2%82%AC" (9 chars).  The output buffer used to be sized at 3 chars per
+     input character, so this overran it. */
+  {
+    const UniChar mb[] = { 0x20AC, 'a', 'b' };
+    CFStringRef mbStr = CFStringCreateWithCharacters (NULL, mb, 3);
+
+    str = CFURLCreateStringByAddingPercentEscapes (NULL, mbStr, NULL, NULL,
+      kCFStringEncodingUTF8);
+    PASS_CFEQ(str, CFSTR("%E2%82%ACab"),
+      "A non-ASCII character is escaped to multi-byte UTF-8 without overflow.");
+    CFRelease (str);
+    CFRelease (mbStr);
+  }
+
   return 0;
 }


### PR DESCRIPTION
`CFURLCreateStringByAddingPercentEscapes` (`Source/CFURL.c`) sizes its output buffer at **3 chars per input character**:
```c
dst = CFAllocatorAllocate (alloc, sizeof(char) * sLength * 3, 0);
```
But `CFURLAppendPercentEscapedForCharacter` encodes each character to up to `MAX_BYTES` bytes in the target encoding and emits a three-character `"%XX"` sequence **per byte**. A non-ASCII character therefore produces more than 3 output chars — e.g. `U+20AC` (`€`) → `E2 82 AC` in UTF-8 → `"%E2%82%AC"` = **9 characters**. `dpos` is never bounds-checked, so the buffer is overrun (heap **write** overflow).

Reachable from the public `CFURLCreateStringByAddingPercentEscapes` with an attacker-controlled string (and internally via the file-system-path / windows-path URL creators).

### Fix
Size the buffer for the worst case — `3 * MAX_BYTES` output chars per input character.

### Validation (valgrind, Ubuntu 24.04 + clang 18)
A one-line repro escaping 64 `U+20AC` characters:

**Before:**
```
Invalid write of size 1 at CFURLAppendPercentEscapedForCharacter (CFURL.c:1415)
  Address ... is 0 bytes after a block of size 192 alloc'd  (CFURL.c:1493)
```
**After:** `ERROR SUMMARY: 0 errors`, and a valid escape still produces correct output (`"€a/"` → `"%E2%82%ACa/"`).

`Tests/CFURL/escaping.m` gains a non-ASCII escaping case (`U+20AC` → `"%E2%82%AC"`). Note: the overflow is silent on a normal build (the decoded output is still correct), so the in-suite test is a functional regression guard; valgrind is the memory-safety proof.
