### PR TITLE
CFUUID: fix out-of-bounds write and byte order in CFUUIDCreateFromString

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-27  DTW-Thalion  <todd.white@thalion.global>
+	* Source/CFUUID.c (CFUUIDCreateFromString): Parse each UUID byte
+	individually (%2hhx) into bytes.byte0..byte15, reject a string lacking
+	all 16 bytes, and size the scratch buffer at 37.
+	* Tests/CFUUID/create.m: Add a CFUUIDCreateFromString round-trip test.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFUUID.c
+++ b/Source/CFUUID.c
@@ -224,15 +224,20 @@ CFUUIDRef
 CFUUIDCreateFromString (CFAllocatorRef alloc, CFStringRef uuidStr)
 {
   CFUUIDBytes bytes;
-  char data[36]; /* 36 chars */
-  if (!CFStringGetCString (uuidStr, data, 36, kCFStringEncodingASCII))
+  char data[37]; /* 36 characters + NUL */
+  if (!CFStringGetCString (uuidStr, data, sizeof(data), kCFStringEncodingASCII))
     return NULL;
-  
-  sscanf (data, "%4hx%4hx-%4hx-%4hx-%4hx-%4hx%4hx%4hx",
-    (UInt16*)&bytes.byte1,(UInt16*)&bytes.byte3, (UInt16*)&bytes.byte5,
-    (UInt16*)&bytes.byte7, (UInt16*)&bytes.byte9, (UInt16*)&bytes.byte11,
-    (UInt16*)&bytes.byte13, (UInt16*)&bytes.byte15);
-  
+
+  /* Parse each byte individually into bytes.byte0..byte15. */
+  if (sscanf (data,
+        "%2hhx%2hhx%2hhx%2hhx-%2hhx%2hhx-%2hhx%2hhx-%2hhx%2hhx-"
+        "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
+        &bytes.byte0, &bytes.byte1, &bytes.byte2, &bytes.byte3,
+        &bytes.byte4, &bytes.byte5, &bytes.byte6, &bytes.byte7,
+        &bytes.byte8, &bytes.byte9, &bytes.byte10, &bytes.byte11,
+        &bytes.byte12, &bytes.byte13, &bytes.byte14, &bytes.byte15) != 16)
+    return NULL;
+
   return CFUUIDCreateFromUUIDBytes (alloc, bytes);
 }
 

--- a/Tests/CFUUID/create.m
+++ b/Tests/CFUUID/create.m
@@ -22,6 +22,24 @@ int main (void)
   
   CFRelease (uuid1);
   CFRelease (str);
-  
+
+  /* CFUUIDCreateFromString must parse the 16 bytes correctly and round-trip.
+     The old parser byte-swapped and shifted the bytes (and wrote past the
+     16-byte struct), so this produced a garbage UUID. */
+  {
+    CFStringRef in = CFSTR("12345678-1234-1234-1234-123456789012");
+    CFUUIDRef uuid3 = CFUUIDCreateFromString (NULL, in);
+    CFStringRef back;
+
+    PASS_CF(uuid3 != NULL, "CFUUIDCreateFromString() returns non-NULL.");
+    back = uuid3 ? CFUUIDCreateString (NULL, uuid3) : NULL;
+    PASS_CFEQ(back, in,
+      "A UUID string round-trips through CFUUIDCreateFromString.");
+    if (back)
+      CFRelease (back);
+    if (uuid3)
+      CFRelease (uuid3);
+  }
+
   return 0;
 }


### PR DESCRIPTION
`CFUUIDCreateFromString` (`Source/CFUUID.c`) parsed the UUID string with:
```c
char data[36];
...
sscanf (data, "%4hx%4hx-%4hx-%4hx-%4hx-%4hx%4hx%4hx",
  (UInt16*)&bytes.byte1, (UInt16*)&bytes.byte3, ... (UInt16*)&bytes.byte15);
```
This has several bugs:
- **Out-of-bounds write:** `CFUUIDBytes` is 16 bytes (`byte0`..`byte15`). `(UInt16*)&bytes.byte15` writes offsets 15–16; offset 16 is one byte past the struct.
- **Uninitialised byte:** `byte0` is never written (the first `%4hx` targets `byte1`), so a stack byte leaks into the returned UUID.
- **Wrong byte order:** each `%4hx` stores a `UInt16` in host order, byte-swapping every pair on little-endian hosts.
- **Buffer one byte short:** a full 36-character UUID needs 37 bytes (incl. NUL); `data[36]` cannot hold it.

Net effect: the function produced a garbage UUID. `"12345678-1234-1234-1234-123456789012"` round-tripped to `"…0341278-5634-…"`.

### Fix
Parse each byte with `%2hhx` directly into `byte0..byte15`, reject a string that doesn't contain all 16 bytes, and size the buffer at 37.

### Validation (Ubuntu 24.04 + clang 18)
`Tests/CFUUID/create.m` gains a round-trip test (`CFUUIDCreateFromString` → `CFUUIDCreateString`). **Before:** fails (garbage). **After:** round-trips exactly, and valgrind reports `0 errors`.
