### PR TITLE
CFDateFormatter: clamp string length before copying to fixed buffer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-06-27  DTW-Thalion  <todd.white@thalion.global>
+	* Source/CFDateFormatter.c (CFDateFormatterGetAbsoluteTimeFromString):
+	Fix buffer overflow.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFDateFormatter.c
+++ b/Source/CFDateFormatter.c
@@ -595,8 +595,10 @@ CFDateFormatterGetAbsoluteTimeFromString (CFDateFormatterRef fmt,
     range = *rangep;
   else
     range = CFRangeMake (0, CFStringGetLength(string));
+  if (range.length > BUFFER_SIZE)
+    range.length = BUFFER_SIZE;
   CFStringGetCharacters (string, range, text);
-  
+
   udate = udat_parse (fmt->_fmt, text, range.length, &pPos, &err);
   if (U_FAILURE(err))
     return false;


### PR DESCRIPTION
`CFDateFormatterGetAbsoluteTimeFromString` (`Source/CFDateFormatter.c`) copies the input string into a fixed stack buffer with no length clamp:
```c
UniChar text[BUFFER_SIZE];
...
range = CFRangeMake (0, CFStringGetLength(string));   /* or a caller range */
CFStringGetCharacters (string, range, text);          /* writes range.length UniChars */
```
A string longer than `BUFFER_SIZE` (256) overflows the stack buffer. Reachable from the public `CFDateFormatterGetAbsoluteTimeFromString` / `CFDateFormatterCreateDateFromString` with an attacker-controlled date string.

### Fix
Clamp `range.length` to `BUFFER_SIZE` before the copy — matching the sibling formatter functions (e.g. `CFNumberFormatterGetValueFromString`, which already clamp).

### Validation (Ubuntu 24.04 + clang 18)
`Tests/CFDateFormatter/basic.m` gains a long-string case. **Before:** a 5000-character string SIGSEGVs (the test aborts). **After:** it is handled without overflowing the buffer.
