### PR TITLE
CFString: reject invalid encoding in CFStringAppendCString (heap overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-06-27  DTW-Thalion  <todd.white@thalion.global>
+	* Source/CFString.c (CFStringAppendCString): Check for invalid encoding.
+	* Tests/CFString/mutablestring.m: Add a truncated-multibyte append test.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFString.c
+++ b/Source/CFString.c
@@ -1216,6 +1216,8 @@ CFStringAppendCString (CFMutableStringRef str, const char *cStr,
 
   numChars = GSUnicodeFromEncoding (&buffer, buffer + BUFFER_SIZE, encoding,
                                     (const UInt8 **) &cStr, cStrLimit, 0);
+  if (numChars < 0)
+    return;
   if (numChars <= BUFFER_SIZE)
     {
       CFStringAppendCharacters (str, bufferStart, numChars);

--- a/Tests/CFString/mutablestring.m
+++ b/Tests/CFString/mutablestring.m
@@ -47,6 +47,13 @@ int main (void)
   CFStringPad (str1, NULL, 3, 0);
   PASS_CFEQ(str1, CFSTR("abc"), "Truncating works.");
   CFRelease (str1);
-  
+
+  str1 = CFStringCreateMutable (NULL, 0);
+  CFStringAppendCString (str1, "ok", kCFStringEncodingUTF8);
+  CFStringAppendCString (str1, "\xE2\x82", kCFStringEncodingUTF8);
+  PASS_CF(CFStringGetLength (str1) == 2,
+    "Appending a truncated multi-byte C string does not overflow.");
+  CFRelease (str1);
+
   return 0;
 }

--- a/Tests/CFTimeZone/GNUmakefile
+++ b/Tests/CFTimeZone/GNUmakefile
@@ -1,0 +1,32 @@
+# __GENERATED__ makefile marker
+#
+
+include $(GNUSTEP_MAKEFILES)/common.make
+-include ../GNUmakefile.super
+
+GNUSTEP_OBJ_DIR=./obj
+
+TEST_TOOL_NAME =  cache_retain
+
+ADDITIONAL_CPPFLAGS += -I$(GNUSTEP_MAKEFILES)/TestFramework
+
+ifeq ($(gcov),yes)
+ADDITIONAL_OBJCFLAGS += -ftest-coverage -fprofile-arcs
+ADDITIONAL_OBJCCFLAGS += -ftest-coverage -fprofile-arcs
+ADDITIONAL_LDFLAGS += -ftest-coverage -fprofile-arcs
+ADDITIONAL_TOOL_LIBS+=-lgcov
+endif
+
+
+cache_retain_OBJC_FILES=cache_retain.m
+
+-include GNUmakefile.preamble
+-include make-check.mak
+include $(GNUSTEP_MAKEFILES)/test-tool.make
+-include GNUmakefile.postamble
+
+after-clean::
+	rm -f core core.* *.core \
+	test_*.out test_*.err \
+	tests.log tests.sum oldtests.log oldtests.sum
+


### PR DESCRIPTION
* Source/CFString.c (CFStringAppendCString): GSUnicodeFromEncoding returns -1
when the C string is invalid in the given encoding (e.g. a truncated multi-byte
sequence).  The check "numChars <= BUFFER_SIZE" is true for -1, so
CFStringAppendCharacters(str, buf, -1) ran and its
memcpy(.., numChars * sizeof(UniChar)) copied (size_t)-1 bytes -- a heap
overflow.  Return early when numChars < 0.
* Tests/CFString/mutablestring.m: add a truncated-multibyte append test.
* ChangeLog: document the above.

Reachable from the public CFStringAppendCString.  A truncated UTF-8 sequence
("\xE2\x82") SIGSEGVs the unpatched build (test aborts) and is ignored after
the fix.

