### PR TITLE
CFStringCreateByCombiningStrings: fix OOB read on empty array

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/CFStringUtilities.c (CFStringCreateByCombiningStrings):
+	Guard against an empty array.  The count was computed as
+	CFArrayGetCount() - 1, so an empty array yielded -1, the
+	"count == 0" early return was bypassed, and the function read
+	CFArrayGetValueAtIndex(theArray, 0) past the end of empty
+	storage.  Return NULL when the array has no elements.
+	* Tests/CFString/general.m: Regression test for the empty-array
+	case.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFStringUtilities.c
+++ b/Source/CFStringUtilities.c
@@ -260,7 +260,7 @@ CFStringCreateByCombiningStrings (CFAllocatorRef alloc, CFArrayRef theArray,
   CFStringRef ret;
   
   count = CFArrayGetCount (theArray) - 1;
-  if (count == 0)
+  if (count <= 0)
     return NULL;
   
   string = CFStringCreateMutable (NULL, 0);

--- a/Tests/CFString/general.m
+++ b/Tests/CFString/general.m
@@ -1,4 +1,5 @@
 #include "CoreFoundation/CFString.h"
+#include "CoreFoundation/CFArray.h"
 #include "../CFTesting.h"
 
 int main (void)
@@ -26,6 +27,12 @@ int main (void)
        (int)found.location, (int)found.length);
   
   CFRelease (str);
-  
+
+  /* An empty array must not read past the end of its (empty) storage. */
+  array = CFArrayCreate (NULL, NULL, 0, &kCFTypeArrayCallBacks);
+  str = CFStringCreateByCombiningStrings (NULL, array, CFSTR(","));
+  PASS_CF(str == NULL, "Combining an empty array returns NULL without overreading.");
+  CFRelease (array);
+
   return 0;
 }


### PR DESCRIPTION
count = CFArrayGetCount(theArray) - 1 is -1 for an empty array, so the
"count == 0" guard was bypassed and the function dereferenced
CFArrayGetValueAtIndex(theArray, 0), reading 8 bytes past the end of the
empty array storage (confirmed under valgrind: "Invalid read of size 8
... 0 bytes after a block").  Reachable from the public API with any
empty CFArray.

Change the guard to "count <= 0" so an empty array returns NULL before
the unguarded access; the one-element behaviour (count == 0) is
unchanged.  Adds a regression test to Tests/CFString/general.m.

