### PR TITLE
CFStringEncoding: fix OOB read past str_encoding_table

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/CFStringEncoding.c (CFStringEncodingTableIndex): Handle
+	unknown encodings gracefully.
+	* Tests/CFString/encodings.m: Regression test for an unknown
+	encoding.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFStringEncoding.c
+++ b/Source/CFStringEncoding.c
@@ -241,7 +241,7 @@ CFStringEncodingTableIndex (CFStringEncoding encoding)
   while (idx < str_encoding_table_size
          && str_encoding_table[idx].enc != encoding)
     idx++;
-  return idx;
+  return idx < str_encoding_table_size ? idx : -1;
 }
 
 CF_INLINE const char *
@@ -251,6 +251,8 @@ CFStringICUConverterName (CFStringEncoding encoding)
   CFIndex idx;
 
   idx = CFStringEncodingTableIndex (encoding);
+  if (idx < 0)
+    return NULL;
   name = str_encoding_table[idx].converterName;
 
   return name;
@@ -264,6 +266,8 @@ GSStringOpenConverter (CFStringEncoding encoding, char lossByte)
   UErrorCode err = U_ZERO_ERROR;
 
   converterName = CFStringICUConverterName (encoding);
+  if (converterName == NULL)
+    return NULL;
 
   cnv = ucnv_open (converterName, &err);
   if (U_FAILURE (err))
@@ -392,6 +396,8 @@ CFStringConvertEncodingToIANACharSetName (CFStringEncoding encoding)
   UErrorCode err = U_ZERO_ERROR;
 
   cnvName = CFStringICUConverterName (encoding);
+  if (cnvName == NULL)
+    return NULL;
   name = ucnv_getStandardName (cnvName, "IANA", &err);
   if (U_FAILURE (err))
     return NULL;
@@ -457,6 +463,8 @@ UInt32
 CFStringConvertEncodingToWindowsCodepage (CFStringEncoding encoding)
 {
   CFIndex idx = CFStringEncodingTableIndex (encoding);
+  if (idx < 0)
+    return 0;
   return str_encoding_table[idx].winCodepage;
 }
 

--- a/Tests/CFString/encodings.m
+++ b/Tests/CFString/encodings.m
@@ -77,6 +77,11 @@ int main (void)
   
   CFRelease (str_utf8);
   CFRelease (str_utf16);
-  
+
+  PASS_CF (CFStringConvertEncodingToWindowsCodepage (0x0BFF) == 0,
+           "Unknown encoding maps to codepage 0 without overreading the table.");
+  PASS_CF (CFStringConvertEncodingToIANACharSetName (0x0BFF) == NULL,
+           "Unknown encoding maps to NULL IANA name without overreading the table.");
+
   return 0;
 }


### PR DESCRIPTION
CFStringEncodingTableIndex() returned str_encoding_table_size (the count,
i.e. one past the last valid index) when the requested encoding was not
in the table.  Callers then dereferenced str_encoding_table[size],
reading past the end of the global array.  AddressSanitizer:

  global-buffer-overflow ... 16 bytes after global variable
  str_encoding_table ... in CFStringConvertEncodingToWindowsCodepage
  (CFStringEncoding.c:460)
  global-buffer-overflow ... 8 bytes after global variable
  str_encoding_table ... in CFStringICUConverterName
  (CFStringEncoding.c:254)

Both are reachable from the public API with any encoding that is absent
from the table (e.g. kCFStringEncodingNonLossyASCII, 0x0BFF):
CFStringConvertEncodingToWindowsCodepage,
CFStringConvertEncodingToIANACharSetName, and internally
GSStringOpenConverter.

Make CFStringEncodingTableIndex() return -1 on miss and have every
caller treat that as "unknown": NULL converter name (so the converter
fails to open rather than reading garbage) and codepage 0.  Adds a
regression test to Tests/CFString/encodings.m.

