### PR TITLE
CFDate: fix OOB read of _daysBeforeMonth in CFAbsoluteTimeToFields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/CFDate.c (CFAbsoluteTimeToFields): Fix the month-finding
+	loop, which started at the wrong table index and scanned in the
+	wrong direction, walking off the end of _daysBeforeMonth (a
+	24-element global) for in-range days and computing a bogus month
+	and day.  Scan forward within the correct half of the table and
+	stop at the last month.
+	* Tests/CFDate/basic.m: Regression test for CFAbsoluteTimeGetGregorianDate.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFDate.c
+++ b/Source/CFDate.c
@@ -199,11 +199,14 @@ CFAbsoluteTimeToFields (CFAbsoluteTime at, SInt32 *year, SInt8 *month,
   if (dayOfYear)
     *dayOfYear = d;
   
-  M = isLeap ? 11 : 13;
-  while (d < _daysBeforeMonth[M])
+  /* Find the month by walking forward through the half of the table that
+     corresponds to the year type (leap years start at index 12).  Stop at
+     the last month so we never index past the end of _daysBeforeMonth. */
+  M = isLeap ? 12 : 0;
+  while (M < (isLeap ? 23 : 11) && d >= _daysBeforeMonth[M + 1])
     ++M;
   if (month)
-    *month = ++M;
+    *month = (isLeap ? M - 12 : M) + 1;
   if (day)
     *day = d - _daysBeforeMonth[M] + 1;
   

--- a/Tests/CFDate/basic.m
+++ b/Tests/CFDate/basic.m
@@ -17,6 +17,24 @@ int main (void)
   
   CFRelease (date);
   CFRelease (date2);
-  
+
+  /* CFAbsoluteTimeToFields walked _daysBeforeMonth past its end when
+     locating the month; check both halves of the table (non-leap and
+     leap years). */
+  {
+    CFGregorianDate g;
+
+    g = CFAbsoluteTimeGetGregorianDate (0.0, NULL);
+    PASS_CF(g.year == 2001 && g.month == 1 && g.day == 1,
+      "GregorianDate for absolute time 0 is 2001-01-01 (got %d-%02d-%02d).",
+      (int)g.year, (int)g.month, (int)g.day);
+
+    /* 2004 is a leap year; 1154 days after 2001-01-01 is the leap day. */
+    g = CFAbsoluteTimeGetGregorianDate (86400.0 * 1154, NULL);
+    PASS_CF(g.year == 2004 && g.month == 2 && g.day == 29,
+      "GregorianDate for the leap day is 2004-02-29 (got %d-%02d-%02d).",
+      (int)g.year, (int)g.month, (int)g.day);
+  }
+
   return 0;
 }


### PR DESCRIPTION
The month-finding loop in CFAbsoluteTimeToFields() started at
_daysBeforeMonth[isLeap ? 11 : 13] and incremented while
(d < _daysBeforeMonth[M]).  Because the table is monotonically
increasing within each half, that test stays true and the loop keeps
advancing M past the end of the 24-element array.  AddressSanitizer, for
a trivial call:

  global-buffer-overflow ... 0 bytes after global variable
  _daysBeforeMonth ... in CFAbsoluteTimeToFields (CFDate.c:203)
  ... in CFAbsoluteTimeGetGregorianDate (CFDate.c:279)

It is reached from the public CFAbsoluteTimeGetGregorianDate() with any
ordinary date (e.g. absolute time 0 => 2001-01-01); besides the
out-of-bounds read it returned a nonsense month/day (2001-28--1).

Walk forward from the start of the half of the table that matches the
year type (leap years begin at index 12) and stop at the last month, so
the index stays within bounds.  Adds a regression test exercising both
halves of the table (2001-01-01 and the 2004-02-29 leap day).

