### PR TITLE
GSUnicode: fix wild read in _read_number for multi-digit numbers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/GSUnicode.c (_read_number): Fix operator precedence in
+	the digit loop.
+	* Tests/CFString/format_int.m: Test a multi-digit field width.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/GSUnicode.c
+++ b/Source/GSUnicode.c
@@ -1166,7 +1166,7 @@ _read_number (const UniChar ** __restrict__ format)
    * is used for.
    */
   while ((**format >= '0') && (**format <= '9') && (*format - start < 3))
-    number = (number * 10) + (*(*format++) - '0');
+    number = (number * 10) + (*(*format)++ - '0');
 
   return number;
 }

--- a/Tests/CFString/format_int.m
+++ b/Tests/CFString/format_int.m
@@ -301,6 +301,10 @@ int main (void)
   PASS_CFEQ (str1, CFSTR ("ffffff85"), "Negative hex formatted correctly");
   CFRelease (str1);
 
+  str1 = CFStringCreateWithFormat (NULL, NULL, CFSTR("%10d"), 1234567890);
+  PASS_CFEQ (str1, CFSTR ("1234567890"), "Multi-digit width parsed correctly");
+  CFRelease (str1);
+
   return 0;
 }
 


### PR DESCRIPTION
In the digit-accumulation loop, "*(*format++)" parsed as
"*(*(format++))": the postfix ++ incremented the local copy of the
pointer-to-the-format-pointer rather than advancing the format pointer
via "(*format)++".  As a result the caller's cursor was never advanced
inside the loop, and on the next iteration "**format" dereferenced the
stack slot just past the format-pointer variable -- a wild read.

Reachable from CFStringCreateWithFormat with any multi-digit field
width, precision, or argument position (e.g. "%10d").  Under valgrind:

  Use of uninitialised value of size 8 ... _read_number (GSUnicode.c:1168)
  Invalid read of size 2 ... _read_number (GSUnicode.c:1168)

Use "*(*format)++" so the format cursor advances correctly.  Adds a
multi-digit-width regression test.

