### PR TITLE
GSUnicode: fix uninitialised padding gaps in _pad

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/GSUnicode.c (_pad): Advance obuf between PAD_SIZE chunks
+	so wide padding is written contiguously instead of overwriting the
+	same position and leaving uninitialised gaps in the output.
+	* Tests/CFString/format_int.m: Tests for padding wider than PAD_SIZE.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/GSUnicode.c
+++ b/Source/GSUnicode.c
@@ -1243,7 +1243,10 @@ _pad (UniChar * obuf, UniChar * obuf_end, const UniChar padchar, CFIndex len)
       else
         pad_string = _pad_zero;
       for (; len > PAD_SIZE; len -= PAD_SIZE)
-        written += _write (obuf, obuf_end, (UniChar *) pad_string, PAD_SIZE);
+        {
+          written += _write (obuf, obuf_end, (UniChar *) pad_string, PAD_SIZE);
+          obuf += PAD_SIZE;
+        }
       written += _write (obuf, obuf_end, (UniChar *) pad_string, len);
     }
   return written;

--- a/Tests/CFString/format_int.m
+++ b/Tests/CFString/format_int.m
@@ -301,6 +301,20 @@ int main (void)
   PASS_CFEQ (str1, CFSTR ("ffffff85"), "Negative hex formatted correctly");
   CFRelease (str1);
 
+  /* Padding wider than PAD_SIZE (8) must advance the output cursor between
+     chunks; otherwise the buffer is left with uninitialised gaps. */
+  str1 = CFStringCreateWithFormat (NULL, NULL, CFSTR("%*d"), 12, 5);
+  PASS_CFEQ (str1, CFSTR ("           5"), "Wide space padding is contiguous");
+  CFRelease (str1);
+
+  str1 = CFStringCreateWithFormat (NULL, NULL, CFSTR("%-*d"), 12, 5);
+  PASS_CFEQ (str1, CFSTR ("5           "), "Wide left-aligned padding is contiguous");
+  CFRelease (str1);
+
+  str1 = CFStringCreateWithFormat (NULL, NULL, CFSTR("%0*d"), 12, 5);
+  PASS_CFEQ (str1, CFSTR ("000000000005"), "Wide zero padding is contiguous");
+  CFRelease (str1);
+
   return 0;
 }
 


### PR DESCRIPTION
_pad() emits field padding in PAD_SIZE (8) character chunks, but it never
advanced obuf inside the chunk loop, so every chunk wrote to the same
position.  For any padding wider than 8 characters the earlier chunks
were overwritten and the skipped output positions were left
uninitialised; those bytes then appeared in the formatted string (and
were read out when converting it).  Under valgrind a padded format such
as "%*d" with width 12 produced garbage output and:

  Conditional jump or move depends on uninitialised value(s)

Advance obuf by PAD_SIZE on each chunk so the padding is written
contiguously.  Adds regression tests for wide space, left-aligned, and
zero padding.

