### PR TITLE
CFString: fix one-byte overflow in CFStringGetCString

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/CFString.c (CFStringGetCString): Fix buffer overflow.
+	* Tests/CFString/create.m: Regression test for CFStringGetCString
+	with a buffer that has no room for the NUL.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFString.c
+++ b/Source/CFString.c
@@ -877,7 +877,7 @@ CFStringGetCString (CFStringRef str, char *buffer, CFIndex bufferSize,
 
   if (CFStringGetBytes (str, CFRangeMake (0, len), encoding, 0, false,
                         (UInt8 *) buffer, bufferSize, &used) == len
-      && used <= len)
+      && used <= len && used < bufferSize)
     {
       buffer[used] = '\0';
       return true;

--- a/Tests/CFString/create.m
+++ b/Tests/CFString/create.m
@@ -1,5 +1,6 @@
 #include "CoreFoundation/CFString.h"
 #include "../CFTesting.h"
+#include <string.h>
 
 int main (void)
 {
@@ -29,6 +30,20 @@ int main (void)
   CFRelease(str2);
   CFRelease(string);
   CFRelease(array);
-  
+
+  {
+    char b[8];
+    Boolean ok;
+
+    memset (b, 'X', sizeof b);
+    ok = CFStringGetCString (CFSTR("hello"), b, 5, kCFStringEncodingASCII);
+    PASS_CF(ok == false, "GetCString fails when there is no room for the NUL.");
+    PASS_CF(b[5] == 'X', "GetCString did not write past the requested size.");
+
+    ok = CFStringGetCString (CFSTR("hello"), b, 6, kCFStringEncodingASCII);
+    PASS_CF(ok && strcmp (b, "hello") == 0,
+      "GetCString succeeds when the buffer has room for the NUL.");
+  }
+
   return 0;
 }


### PR DESCRIPTION
CFStringGetCString() wrote the terminating NUL with "buffer[used] = 0"
after checking only "used <= len".  When the converted bytes exactly
fill the caller's buffer (used == bufferSize), that NUL is written one
byte past the end.  Under valgrind, for a buffer sized to the content
with no room for the terminator:

  Invalid write of size 1 ... CFStringGetCString (CFString.c:882)

and the call still returned true.  It is reachable from the public API
with any buffer exactly as large as the encoded string.

Require room for the terminator (used < bufferSize) before writing it;
otherwise return false, matching the documented "buffer too small"
behaviour.  Adds a regression test to Tests/CFString/create.m.

