### PR TITLE
CFURL: fix out-of-bounds read when unescaping a trailing percent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-27  Todd White  <todd.white@thalion.global>
+	* Source/CFURL.c (CFURLCreateStringByReplacingPercentEscapesUsingEncoding):
+	Bound the percent-escape hex-digit and look-ahead reads against the
+	string length so a trailing '%' does not read past the end.
+	* Tests/CFURL/escaping.m: Regression test for a trailing '%'.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFURL.c
+++ b/Source/CFURL.c
@@ -1591,7 +1591,12 @@ CFURLCreateStringByReplacingPercentEscapesUsingEncoding (CFAllocatorRef alloc,
       limit = buffer + BUFFER_SIZE;
       do
         {
-          ch = CFStringGetCharacterAtIndex (origString, ++i);
+          if (++i >= origLen)
+            {
+              success = false;
+              break;
+            }
+          ch = CFStringGetCharacterAtIndex (origString, i);
           if (ch >= '0' && ch <= '9')
             {
               *current = ch - '0';
@@ -1606,7 +1611,12 @@ CFURLCreateStringByReplacingPercentEscapesUsingEncoding (CFAllocatorRef alloc,
               break;
             }
           *current <<= 4;
-          ch = CFStringGetCharacterAtIndex (origString, ++i);
+          if (++i >= origLen)
+            {
+              success = false;
+              break;
+            }
+          ch = CFStringGetCharacterAtIndex (origString, i);
           if (ch >= '0' && ch <= '9')
             {
               *current |= ch - '0';
@@ -1621,7 +1631,8 @@ CFURLCreateStringByReplacingPercentEscapesUsingEncoding (CFAllocatorRef alloc,
               break;
             }
           ++current;
-          ch = CFStringGetCharacterAtIndex (origString, ++i);
+          ch = (++i < origLen)
+            ? CFStringGetCharacterAtIndex (origString, i) : 0;
         }
       while (current < limit && ch == '%');
       if (success == false)

--- a/Tests/CFURL/escaping.m
+++ b/Tests/CFURL/escaping.m
@@ -1,6 +1,10 @@
 #include "CoreFoundation/CFURL.h"
+#include "CoreFoundation/CFString.h"
 
 #include "../CFTesting.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 int main (void)
 {
@@ -36,9 +40,29 @@ int main (void)
   
   str2 = CFURLCreateStringByReplacingPercentEscapes (NULL, str, CFSTR(""));
   PASS_CFEQ(str2, urlStr, "Percent escapes replaced correctly.");
-  
+
   CFRelease (str);
   CFRelease (str2);
-  
+
+  /* A '%' with no following hex digits must be rejected without reading
+     past the end of the string.  Use a no-copy string with an exact-size
+     backing buffer so an over-read is a genuine out-of-bounds access. */
+  {
+    char *raw = malloc (4);
+    CFStringRef trailing;
+
+    memcpy (raw, "abc%", 4);
+    trailing = CFStringCreateWithBytesNoCopy (NULL, (const UInt8 *) raw, 4,
+      kCFStringEncodingASCII, false, kCFAllocatorNull);
+    str2 = CFURLCreateStringByReplacingPercentEscapes (NULL, trailing,
+      CFSTR(""));
+    PASS_CF(str2 == NULL,
+      "A trailing '%%' is rejected without overreading the string.");
+    if (str2 != NULL)
+      CFRelease (str2);
+    CFRelease (trailing);
+    free (raw);
+  }
+
   return 0;
 }


### PR DESCRIPTION
CFURLCreateStringByReplacingPercentEscapesUsingEncoding() read the two
hex digits (and the following look-ahead character) after a '%' with
"CFStringGetCharacterAtIndex(origString, ++i)" and never checked i
against the string length.  A string ending in '%' (or '%' followed by a
single hex digit) therefore read one or more characters past the end.
CFStringGetCharacterAtIndex indexes the backing store directly, so for a
string whose buffer is exactly its length (e.g. a no-copy string) this is
a genuine out-of-bounds read.  Under valgrind, for "abc%":

  Invalid read of size 1 ... CFURLCreateStringByReplacingPercentEscapesUsingEncoding (CFURL.c:1594)

It is reachable from the public CFURLCreateStringByReplacingPercentEscapes.

Bound each index against origLen: a '%' not followed by two hex digits is
rejected (success = false), and the look-ahead for a further '%' yields 0
at the end of the string so the loop terminates normally.  Adds a
regression test using a no-copy string ending in '%'.

