### PR TITLE
CFLocale: pass the real buffer size to uloc_canonicalize

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFLocale.c (CFLocaleCreateCanonicalLanguageIdentifierFromString):
+	Pass the real buffer size to uloc_canonicalize.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFLocale.c
+++ b/Source/CFLocale.c
@@ -861,7 +861,7 @@ CFLocaleCreateCanonicalLanguageIdentifierFromString (CFAllocatorRef allocator,
          kCFStringEncodingASCII))
     return NULL;
   
-  uloc_canonicalize (cLocale, canonical, BUFFER_SIZE, &err);
+  uloc_canonicalize (cLocale, canonical, ULOC_FULLNAME_CAPACITY, &err);
   uloc_getLanguage (canonical, lang, ULOC_LANG_CAPACITY, &err);
   if (U_FAILURE(err))
     return NULL;


### PR DESCRIPTION
CFLocaleCreateCanonicalLanguageIdentifierFromString() declares
"char canonical[ULOC_FULLNAME_CAPACITY]" (157) but told ICU the buffer
was BUFFER_SIZE (256):

  uloc_canonicalize (cLocale, canonical, BUFFER_SIZE, &err);

If uloc_canonicalize ever produced more than ULOC_FULLNAME_CAPACITY
bytes it could write up to BUFFER_SIZE, overrunning the stack buffer.
The sibling CFLocaleCreateCanonicalLocaleIdentifierFromString() already
passes ULOC_FULLNAME_CAPACITY correctly; make this one consistent.

This is a latent size/argument mismatch rather than an observed overflow
(the input identifier is itself bounded to ULOC_FULLNAME_CAPACITY a few
lines above), so no crash test accompanies it; the added test just
exercises the canonicalization path.

