### PR TITLE
CFTimeZone: validate TZif header counts before parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFTimeZone.c (CFTimeZoneCreate): Validate the TZif header
+	counts before parsing: reject negative counts, require the declared
+	transition/type/abbreviation data to fit within the supplied data,
+	reject out-of-range transition type indices, size the abbreviation
+	array to TZ_MAX_CHARS, and bound the abbreviation loop and the
+	terminating-NUL scan by the end of the character data.
+	* Tests/CFTimeZone/basic.m: Regression test for a truncated TZif.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFTimeZone.c
+++ b/Source/CFTimeZone.c
@@ -173,11 +173,31 @@ CFTimeZoneCreate (CFAllocatorRef alloc, CFStringRef name, CFDataRef data)
   tzh_typecnt = (SInt32)CFSwapInt32BigToHost (*tmp);
   tmp = (UInt32*)header->tzh_charcnt;
   tzh_charcnt = (SInt32)CFSwapInt32BigToHost (*tmp);
-  /* Make sure we're not above any of the maximums. */
+  /* Make sure the counts are sane: not negative, not above the maximums,
+     and that the data they describe actually fits in what follows the
+     header (otherwise the parsing below reads out of bounds). */
+  if (tzh_timecnt < 0 || tzh_typecnt < 0 || tzh_charcnt < 0)
+    return NULL;
   if (tzh_timecnt > TZ_MAX_TIMES || tzh_typecnt > TZ_MAX_TYPES
       || tzh_charcnt > TZ_MAX_CHARS)
     return NULL;
-  
+  if (tzh_timecnt > 0 && tzh_typecnt < 1)
+    return NULL;
+  if ((sizeof (SInt32) + sizeof (UInt8)) * (size_t)tzh_timecnt
+        + sizeof (struct _ttinfo) * (size_t)tzh_typecnt
+        + (size_t)tzh_charcnt
+      > (size_t)(endOfBytes - bytes))
+    return NULL;
+  /* Every transition references a local time type by index; reject the
+     file if any index is out of range so types[*typeIdx] stays in bounds. */
+  {
+    const UInt8 *ti = bytes + sizeof (SInt32) * tzh_timecnt;
+    SInt32 k;
+    for (k = 0 ; k < tzh_timecnt ; ++k)
+      if (ti[k] >= tzh_typecnt)
+        return NULL;
+  }
+
   new = (struct __CFTimeZone*)_CFRuntimeCreateInstance (alloc,
     _kCFTimeZoneTypeID, CFTIMEZONE_SIZE, 0);
   if (new)
@@ -189,7 +209,7 @@ CFTimeZoneCreate (CFAllocatorRef alloc, CFStringRef name, CFDataRef data)
       struct _ttinfo *types;
       char *chars;
       char *charsEnd;
-      CFStringRef abbrevs[TZ_MAX_CHARS / 4];
+      CFStringRef abbrevs[TZ_MAX_CHARS];
       
       new->_name = CFStringCreateCopy (alloc, name);
       new->_data = CFDataCreateCopy (alloc, data);
@@ -219,13 +239,14 @@ CFTimeZoneCreate (CFAllocatorRef alloc, CFStringRef name, CFDataRef data)
       
       /* Abbreviations */
       idx = 0;
-      while (chars < charsEnd)
+      while (chars < charsEnd && idx < TZ_MAX_CHARS)
         {
           abbrevs[idx++] =
             CFStringCreateWithCString (alloc, chars, kCFStringEncodingASCII);
-          while (*chars != '\0')
+          while (chars < charsEnd && *chars != '\0')
             chars++;
-          chars++; /* Skip '\0' */
+          if (chars < charsEnd)
+            chars++; /* Skip '\0' */
         }
       
       new->_abbrevs = CFAllocatorAllocate (alloc, sizeof(void*) * idx, 0);

--- a/Tests/CFTimeZone/basic.m
+++ b/Tests/CFTimeZone/basic.m
@@ -1,6 +1,9 @@
 #include "CoreFoundation/CFBase.h"
+#include "CoreFoundation/CFData.h"
 #include "CoreFoundation/CFTimeZone.h"
 #include "../CFTesting.h"
+
+#include <string.h>
 
 int main (void)
 {
@@ -25,6 +28,28 @@ int main (void)
   
   CFRelease (str);
   CFRelease (tz);
-  
+
+  /* A TZif whose header declares far more transitions than the data holds
+     must be rejected rather than read out of bounds. */
+  {
+    UInt8 hdr[44 + 16];
+    CFDataRef data;
+    CFStringRef name;
+
+    memset (hdr, 0, sizeof hdr);
+    memcpy (hdr, "TZif", 4);
+    hdr[34] = 0x03; hdr[35] = 0xE8;  /* tzh_timecnt = 1000 (big-endian) */
+    hdr[36] = 0; hdr[37] = 0; hdr[38] = 0; hdr[39] = 1; /* typecnt = 1 */
+    hdr[40] = 0; hdr[41] = 0; hdr[42] = 0; hdr[43] = 4; /* charcnt = 4 */
+    data = CFDataCreate (NULL, hdr, sizeof hdr);
+    name = CFSTR ("Test/Truncated");
+    tz = CFTimeZoneCreate (NULL, name, data);
+    PASS_CF(tz == NULL,
+      "A truncated TZif is rejected without reading out of bounds.");
+    if (tz != NULL)
+      CFRelease (tz);
+    CFRelease (data);
+  }
+
   return 0;
 }


### PR DESCRIPTION
CFTimeZoneCreate() only checked the transition/type/abbreviation counts
from a TZif header against the upper TZ_MAX_* limits.  It never checked
that they were non-negative or that the data they describe actually fits
in the supplied CFData, and it indexed the type table with an
unvalidated file-supplied index.  The abbreviation array was also sized
TZ_MAX_CHARS/4 while up to TZ_MAX_CHARS abbreviations can be present.

With crafted data this is reachable from the public CFTimeZoneCreate().
AddressSanitizer:

  stack-buffer-overflow WRITE ... CFTimeZoneCreate (CFTimeZone.c:224)
    -- abbreviation loop overruns abbrevs[] (charcnt of single-byte
       abbreviations into a TZ_MAX_CHARS/4 array)
  heap-buffer-overflow READ ... CFTimeZoneCreate (CFTimeZone.c:212)
    -- header declares more transitions/types than the data contains

Reject negative counts, require that timecnt*5 + typecnt*6 + charcnt fit
within the data after the header, reject transitions whose type index is
out of range, size abbrevs[] to TZ_MAX_CHARS, and bound both the
abbreviation loop and the '\0' scan by the end of the character data.
Adds a regression test for a truncated TZif.

