### PR TITLE
CFURL: bounds-check file path indexing in CreateWithFileSystemPath

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFURL.c (CFURLCreateWithFileSystemPathRelativeToBase):
+	Bounds-check the file-path character accesses: require a non-empty
+	string before reading index 0 (POSIX/HFS) and at least three
+	characters before reading indices 1 and 2 (Windows), and test the
+	last character (filePathLen - 1) rather than one past the end when
+	deciding whether to append a trailing '/'.
+	* Tests/CFURL/file_system_path.m: Regression test for a directory
+	path that already ends in '/'.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFURL.c
+++ b/Source/CFURL.c
@@ -984,14 +984,16 @@ CFURLCreateWithFileSystemPathRelativeToBase (CFAllocatorRef alloc,
   switch (style)
     {
       case kCFURLPOSIXPathStyle:
-        abs = (CFStringGetCharacterAtIndex(filePath, 0) == '/');
+        abs = (CFStringGetLength(filePath) > 0
+          && CFStringGetCharacterAtIndex(filePath, 0) == '/');
         path = CFURLCreateStringByAddingPercentEscapes (alloc, filePath,
           NULL, NULL, kCFStringEncodingUTF8);
         if (path != filePath)
           CFRetain (path);
         filePathLen = CFStringGetLength(path);
         if (isDirectory
-            && CFStringGetCharacterAtIndex(path, filePathLen) != '/')
+            && (filePathLen == 0
+              || CFStringGetCharacterAtIndex(path, filePathLen - 1) != '/'))
           {
             CFStringRef tmp;
             tmp = CFStringCreateWithFormat (alloc, NULL, CFSTR("%@/"), path);
@@ -1003,12 +1005,14 @@ CFURLCreateWithFileSystemPathRelativeToBase (CFAllocatorRef alloc,
         /* FIXME: I believe HFS path style is like POSIX with ':' instead
          * of '/' as the separator.
          */
-        abs = (CFStringGetCharacterAtIndex(filePath, 0) == ':');
+        abs = (CFStringGetLength(filePath) > 0
+          && CFStringGetCharacterAtIndex(filePath, 0) == ':');
         path = CFURLCreateStringFromHFSPathStyle (alloc, filePath, abs,
           isDirectory);
         break;
       case kCFURLWindowsPathStyle:
-        abs = (CFStringGetCharacterAtIndex(filePath, 1) == ':'
+        abs = (CFStringGetLength(filePath) >= 3
+          && CFStringGetCharacterAtIndex(filePath, 1) == ':'
           && CFStringGetCharacterAtIndex(filePath, 2) == '\\');
         path = CFURLCreateStringFromWindowsPathStyle (alloc, filePath, abs,
           isDirectory);

--- a/Tests/CFURL/file_system_path.m
+++ b/Tests/CFURL/file_system_path.m
@@ -61,6 +61,15 @@ int main (void)
   
   CFRelease (url);
   CFRelease (baseURL);
-  
+
+  /* A directory path that already ends in '/' must not gain a second one:
+     the trailing-separator test must look at the last character, not one
+     past the end of the string. */
+  url = CFURLCreateWithFileSystemPath (NULL, CFSTR("foo/"),
+    kCFURLPOSIXPathStyle, true);
+  str = CFURLGetString (url);
+  PASS_CFEQ(str, CFSTR("foo/"), "A trailing '/' is not duplicated");
+  CFRelease (url);
+
   return false;
 }


### PR DESCRIPTION
CFURLCreateWithFileSystemPathRelativeToBase() indexed the supplied file
path without checking its length:

  * POSIX/HFS read filePath[0] even for an empty string;
  * Windows read filePath[1] and filePath[2] without requiring at least
    three characters -- a genuine out-of-bounds read for a short string
    (valgrind: "Invalid read of size 1 ... CFURL.c:1011" for a one-
    character no-copy string);
  * the POSIX trailing-separator test read path[filePathLen] (one past
    the end) instead of path[filePathLen - 1].

The last one is also a functional bug: because it inspected the byte just
past the string (rather than the final character) it always thought the
path lacked a trailing '/', so a directory path already ending in '/'
gained a second one ("foo/" -> "foo//").

Guard each access by the string length and test the actual last
character.  Adds a regression test for the duplicated-separator case.

(Note: an unrelated out-of-bounds read remains further down in
CFURLCreate_internal for pathological inputs; it predates this change and
is left for a separate fix.)

