### PR TITLE
CFURL: don't dereference a NULL path/string in URL creation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFURL.c (CFURLCreate_internal): Return NULL when the input
+	string is NULL instead of dereferencing it in CFURLStringParse.
+	(CFURLCreateWithFileSystemPathRelativeToBase): Return NULL when the
+	path-style converter (e.g. the HFS stub, or a single-component
+	Windows path) yields NULL, rather than using and releasing it.
+	* Tests/CFURL/file_system_path.m: Regression tests for the HFS and
+	single-component Windows path cases.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFURL.c
+++ b/Source/CFURL.c
@@ -404,7 +404,13 @@ CFURLCreate_internal (CFAllocatorRef alloc, CFStringRef string,
 {
   struct __CFURL *new;
   CFRange ranges[12];
-  
+
+  /* The path-style converters can return NULL (e.g. the HFS converter is
+     a stub, and combining a single path component yields NULL); don't
+     dereference it. */
+  if (string == NULL)
+    return NULL;
+
   if (!CFURLStringParse (string, ranges))
     return NULL;
   
@@ -1016,7 +1022,13 @@ CFURLCreateWithFileSystemPathRelativeToBase (CFAllocatorRef alloc,
       default:
         return NULL;
     }
-  
+
+  /* The path-style converters (notably the HFS stub, and combining a
+     single Windows path component) can return NULL; don't use or release
+     it. */
+  if (path == NULL)
+    return NULL;
+
   if (abs)
     {
       CFMutableStringRef tmp;

--- a/Tests/CFURL/file_system_path.m
+++ b/Tests/CFURL/file_system_path.m
@@ -61,6 +61,18 @@ int main (void)
   
   CFRelease (url);
   CFRelease (baseURL);
-  
+
+  /* Path styles whose converter returns NULL (the HFS stub, and a
+     single-component relative Windows path) must yield NULL rather than
+     dereferencing the NULL intermediate string. */
+  url = CFURLCreateWithFileSystemPath (NULL, CFSTR("foo"),
+    kCFURLHFSPathStyle, false);
+  PASS_CF(url == NULL, "An HFS path yields NULL without crashing.");
+
+  url = CFURLCreateWithFileSystemPath (NULL, CFSTR("c"),
+    kCFURLWindowsPathStyle, false);
+  PASS_CF(url == NULL,
+    "A single-component relative Windows path yields NULL without crashing.");
+
   return false;
 }


### PR DESCRIPTION
CFURLCreate_internal() passed its string argument straight to
CFURLStringParse(), which calls CFStringGetLength() on it.  Several code
paths can hand it NULL: CFURLCreateStringFromHFSPathStyle() is a stub
that always returns NULL, and CFURLCreateStringFromWindowsPathStyle()
returns NULL for a single-component relative path (combining a one-element
array yields NULL).  CFURLCreateWithFileSystemPathRelativeToBase() then
used and released that NULL path as well.

Both are reachable from the public CFURLCreateWithFileSystemPath():

  CFURLCreateWithFileSystemPath(NULL, CFSTR("foo"), kCFURLHFSPathStyle, 0)
  CFURLCreateWithFileSystemPath(NULL, CFSTR("c"), kCFURLWindowsPathStyle, 0)

both crash (NULL dereference in CFStringGetLength, then in CFRelease).

Guard CFURLCreate_internal() against a NULL string, and stop
CFURLCreateWithFileSystemPathRelativeToBase() from using/releasing a NULL
converter result; return NULL instead.  Adds regression tests.

