### PR TITLE
CFURL: guard against negative path indices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFURL.c (CFURLCopyAbsoluteURL): Stop the "remove last path
+	component" scan at the start of the buffer instead of running off
+	the front when the base path contains no '/'.
+	(CFURLHasDirectoryPath): Treat an empty URL string as not a
+	directory path rather than reading index -1.
+	* Tests/CFURL/ref_resolution.m, Tests/CFURL/file_system_path.m:
+	Regression tests.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFURL.c
+++ b/Source/CFURL.c
@@ -726,8 +726,9 @@ CFURLCopyAbsoluteURL (CFURLRef relativeURL)
                               /* Remove last path component */
                               CFIndex count;
                               count = baseRange.length - 1;
-                              while (buffer[--count] != '/');
-                              baseRange.length = count + 1;
+                              while (count > 0 && buffer[count - 1] != '/')
+                                --count;
+                              baseRange.length = count;
                             }
                         }
                       CFStringGetCharacters (relString, range,
@@ -1359,7 +1360,9 @@ Boolean
 CFURLHasDirectoryPath (CFURLRef url)
 {
   CFStringRef str = CFURLGetString (url);
-  return (CFStringGetCharacterAtIndex(str, CFStringGetLength(str) - 1) == '/');
+  CFIndex len = CFStringGetLength (str);
+  return (len > 0
+    && CFStringGetCharacterAtIndex (str, len - 1) == '/');
 }
 
 CFDataRef

--- a/Tests/CFURL/file_system_path.m
+++ b/Tests/CFURL/file_system_path.m
@@ -61,6 +61,13 @@ int main (void)
   
   CFRelease (url);
   CFRelease (baseURL);
-  
+
+  /* CFURLHasDirectoryPath on a URL with an empty string must not read
+     index -1. */
+  url = CFURLCreateWithString (NULL, CFSTR(""), NULL);
+  PASS_CF(CFURLHasDirectoryPath(url) == false,
+    "An empty URL is not a directory path (no negative index).");
+  CFRelease (url);
+
   return false;
 }

--- a/Tests/CFURL/ref_resolution.m
+++ b/Tests/CFURL/ref_resolution.m
@@ -135,8 +135,19 @@ int main (void)
     "g?y/../x resolved against http://a/b/c/d;p?q is http://a/b/c/g?y/../x");
   CFRelease(url3);
   CFRelease(url2);
-  
+
   CFRelease(url);
-  
+
+  /* Resolving against a base whose path has no '/' used to scan backwards
+     off the start of the buffer when removing the last path component. */
+  url = CFURLCreateWithString (NULL, CFSTR("foo"), NULL);
+  url2 = CFURLCreateWithString (NULL, CFSTR("bar"), url);
+  url3 = CFURLCopyAbsoluteURL (url2);
+  PASS_CFEQ(CFURLGetString(url3), CFSTR("bar"),
+    "bar resolved against base 'foo' is 'bar'");
+  CFRelease(url3);
+  CFRelease(url2);
+  CFRelease(url);
+
   return 0;
 }


### PR DESCRIPTION
Two path-handling routines could index a string with a negative position
and read out of bounds (confirmed with AddressSanitizer, both reachable
from public API):

  * CFURLCopyAbsoluteURL(), when removing the last path component of a
    base whose path contains no '/', ran "while (buffer[--count] != '/')"
    with no lower bound and scanned backwards off the start of the buffer
    (heap-buffer-overflow READ at CFURL.c:729).  Resolving "bar" against a
    base of "foo" triggers it.

  * CFURLHasDirectoryPath() read CFStringGetCharacterAtIndex(str,
    CFStringGetLength(str) - 1) without checking for an empty string, so a
    URL with an empty string read index -1 (global-buffer-overflow READ at
    CFURL.c:1362).

Stop the component scan at the start of the buffer (and treat "no '/'" as
an empty directory part, which keeps existing resolutions byte-identical),
and treat an empty URL string as not having a directory path.  Adds
regression tests.

