### PR TITLE
CFArray: fix off-by-one in CFArrayGetLastIndexOfValue

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFArray.c (CFArrayGetLastIndexOfValue): Start the backward
+	scan at range.location + range.length - 1 instead of one past the
+	end of the range.
+	* Tests/CFArray/create.m: Regression test.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFArray.c
+++ b/Source/CFArray.c
@@ -383,7 +383,7 @@ CFArrayGetLastIndexOfValue (CFArrayRef array, CFRange range, const void *value)
     equal = array->_callBacks->equal;
 
   start = range.location;
-  idx = start + range.length;
+  idx = start + range.length - 1;
 
   if (equal)
     {

--- a/Tests/CFArray/create.m
+++ b/Tests/CFArray/create.m
@@ -19,7 +19,13 @@ int main (void)
   
   n = (CFIndex)CFArrayGetValueAtIndex (a, 1);
   PASS_CF(n == 2, "Found value at index %d.", (int)n);
-  
+
+  n = CFArrayGetLastIndexOfValue (a, CFRangeMake(0, ARRAY_SIZE), (const void*)4);
+  PASS_CF(n == 3, "Last index of value 4 is %d.", (int)n);
+  /* Searching the whole array must not read one past the end of the range. */
+  n = CFArrayGetLastIndexOfValue (a, CFRangeMake(0, ARRAY_SIZE), (const void*)99);
+  PASS_CF(n == -1, "Absent value is reported as not found (%d).", (int)n);
+
   CFRelease (a);
   
   a = CFArrayCreate (NULL, NULL, 0, NULL);


### PR DESCRIPTION
CFArrayGetLastIndexOfValue() began its backward scan at
range.location + range.length, i.e. one past the last index in the range
(the last valid index is range.location + range.length - 1).  The first
comparison therefore read one element beyond the range; when the range
covers a full array whose count equals its capacity this is an
out-of-bounds read (AddressSanitizer: heap-buffer-overflow READ in
CFArrayGetValueAtIndex, from CFArrayGetLastIndexOfValue).  The forward
counterpart, CFArrayGetFirstIndexOfValue(), already stops correctly at
range.location + range.length.

Start the scan at range.location + range.length - 1.  An empty range now
also skips the loop instead of reading at range.location.  Adds a
regression test.

