### PR TITLE
GSCArray: fix out-of-bounds access in GSCArrayQuickSort

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/GSCArray.c (GSCArrayQuickSort): Pass the correct partition
+	lengths to the recursive calls; the right partition length was one
+	too large, reading one element past the end of the array.
+	* Tests/CFArray/mutablearray.m: Regression test sorting >16 values.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/GSCArray.c
+++ b/Source/GSCArray.c
@@ -58,10 +58,6 @@ GSCArrayQuickSort (const void **array, CFIndex length,
         }
       GS_EXCHANGE_VALUES (array[stored], array[length - 1]);
 
-      /* The pivot ends up at index "stored", so the left partition has
-         "stored" elements and the right partition has the remaining
-         "length - stored - 1" (passing length - stored read one past the
-         end of the array). */
       GSCArrayQuickSort (array, stored, comparator, context);
       GSCArrayQuickSort (array + stored + 1, length - stored - 1, comparator,
                          context);

--- a/Source/GSCArray.c
+++ b/Source/GSCArray.c
@@ -58,8 +58,12 @@ GSCArrayQuickSort (const void **array, CFIndex length,
         }
       GS_EXCHANGE_VALUES (array[stored], array[length - 1]);
 
-      GSCArrayQuickSort (array, stored - 1, comparator, context);
-      GSCArrayQuickSort (array + stored + 1, length - stored, comparator,
+      /* The pivot ends up at index "stored", so the left partition has
+         "stored" elements and the right partition has the remaining
+         "length - stored - 1" (passing length - stored read one past the
+         end of the array). */
+      GSCArrayQuickSort (array, stored, comparator, context);
+      GSCArrayQuickSort (array + stored + 1, length - stored - 1, comparator,
                          context);
     }
   GSCArrayInsertionSort (array, length, comparator, context);

--- a/Tests/CFArray/mutablearray.m
+++ b/Tests/CFArray/mutablearray.m
@@ -1,6 +1,7 @@
 #include "CoreFoundation/CFArray.h"
 #include "../CFTesting.h"
 #include <string.h>
+#include <stdlib.h>
 
 #define ARRAY_SIZE 5
 const CFIndex array[ARRAY_SIZE] = { 5, 2, 3, 4, 1 };
@@ -43,27 +44,46 @@ int main (void)
   PASS_CF(n == 5, "Index of value between values is %d.", (int)n);
 
   {
-    /* Sorting more than 16 values exercises the quicksort path, whose right
-       partition used to read one element past the end of the array. */
-    CFMutableArrayRef big = CFArrayCreateMutable (NULL, 0, NULL);
-    CFIndex i;
-    CFIndex prev;
-    Boolean ordered = true;
+    /* Sort a shuffled permutation of 1..sz for a range of sizes that straddle
+       the 16-element threshold between the insertion sort and the quicksort
+       path (the latter used to read one element past the end of the array).
+       The sorted result must be exactly 1, 2, ..., sz. */
+    const CFIndex sizes[] = { 1, 2, 5, 15, 16, 17, 33, 64, 100 };
+    const void *shuf[100];
+    CFIndex s;
 
-    for (i = 0; i < 20; i++)
-      CFArrayAppendValue (big, (const void *)(CFIndex)((i * 7 + 3) % 20 + 1));
-    CFArraySortValues (big, CFRangeMake (0, 20), comp, NULL);
-    prev = 0;
-    for (i = 0; i < 20; i++)
+    srand (1);
+    for (s = 0; s < (CFIndex)(sizeof(sizes) / sizeof(sizes[0])); s++)
       {
-        CFIndex v = (CFIndex) CFArrayGetValueAtIndex (big, i);
-        if (v < prev)
-          ordered = false;
-        prev = v;
+        CFIndex sz = sizes[s];
+        CFArrayRef src;
+        CFMutableArrayRef big;
+        Boolean ordered = true;
+        CFIndex i;
+
+        for (i = 0; i < sz; i++)
+          shuf[i] = (const void *)(CFIndex)(i + 1);
+        for (i = sz - 1; i > 0; i--)
+          {
+            CFIndex j = rand () % (i + 1);
+            const void *t = shuf[i];
+            shuf[i] = shuf[j];
+            shuf[j] = t;
+          }
+
+        src = CFArrayCreate (NULL, shuf, sz, NULL);
+        big = CFArrayCreateMutableCopy (NULL, sz, src);
+        CFArraySortValues (big, CFRangeMake (0, sz), comp, NULL);
+
+        for (i = 0; i < sz; i++)
+          if ((CFIndex) CFArrayGetValueAtIndex (big, i) != i + 1)
+            ordered = false;
+
+        PASS_CF(ordered && CFArrayGetCount (big) == sz,
+          "Shuffled range of %d values sorts to ascending order.", (int)sz);
+        CFRelease (big);
+        CFRelease (src);
       }
-    PASS_CF(ordered && CFArrayGetCount (big) == 20,
-      "Sorting more than 16 values produces sorted output.");
-    CFRelease (big);
   }
 
   return 0;

--- a/Tests/CFArray/mutablearray.m
+++ b/Tests/CFArray/mutablearray.m
@@ -41,7 +41,31 @@ int main (void)
   
   n = CFArrayBSearchValues (ma, CFRangeMake(0, len), (const void*)6, comp, NULL);
   PASS_CF(n == 5, "Index of value between values is %d.", (int)n);
-  
+
+  {
+    /* Sorting more than 16 values exercises the quicksort path, whose right
+       partition used to read one element past the end of the array. */
+    CFMutableArrayRef big = CFArrayCreateMutable (NULL, 0, NULL);
+    CFIndex i;
+    CFIndex prev;
+    Boolean ordered = true;
+
+    for (i = 0; i < 20; i++)
+      CFArrayAppendValue (big, (const void *)(CFIndex)((i * 7 + 3) % 20 + 1));
+    CFArraySortValues (big, CFRangeMake (0, 20), comp, NULL);
+    prev = 0;
+    for (i = 0; i < 20; i++)
+      {
+        CFIndex v = (CFIndex) CFArrayGetValueAtIndex (big, i);
+        if (v < prev)
+          ordered = false;
+        prev = v;
+      }
+    PASS_CF(ordered && CFArrayGetCount (big) == 20,
+      "Sorting more than 16 values produces sorted output.");
+    CFRelease (big);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
After partitioning, the pivot ends up at index "stored", so the left
partition holds "stored" elements ([0, stored-1]) and the right partition
holds "length - stored - 1" elements ([stored+1, length-1]).  The
recursive calls passed the wrong lengths:

  GSCArrayQuickSort (array, stored - 1, ...);            /* misses one */
  GSCArrayQuickSort (array + stored + 1, length - stored, ...); /* one too many */

The right call's length was one too large, so the sub-sort accessed
array[length] -- one past the end of the array.  With a CFArray sorted in
place this is an out-of-bounds read (AddressSanitizer: heap-buffer-overflow
in GSCArrayInsertionSort, via GSCArrayQuickSort, for a 17-element array).
The left call's length was one too small, leaving an element unsorted by
the recursion.

Pass "stored" and "length - stored - 1".  Adds a regression test that
sorts more than 16 values.

