### PR TITLE
CFTree: fix null-pointer dereferences in child handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFTree.c (CFTreePrependChild): Set _lastChild to the new
+	child when the tree was empty, instead of NULL.
+	(CFTreeGetChildAtIndex): Stop walking at the end of the child list
+	so an out-of-range index returns NULL instead of dereferencing it.
+	* Tests/CFTree/basic.m: Regression tests.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFTree.c
+++ b/Source/CFTree.c
@@ -189,7 +189,7 @@ CFTreePrependChild (CFTreeRef tree, CFTreeRef newChild)
   newChild->_nextSibling = tree->_firstChild;
   tree->_firstChild = newChild;
   if (tree->_lastChild == NULL)
-    tree->_lastChild = NULL;
+    tree->_lastChild = newChild;
 }
 
 void
@@ -240,9 +240,9 @@ CFTreeGetChildAtIndex (CFTreeRef tree, CFIndex idx)
   
   j = 0;
   child = tree->_firstChild;
-  while (j++ < idx)
+  while (child != NULL && j++ < idx)
     child = child->_nextSibling;
-  
+
   return child;
 }
 

--- a/Tests/CFTree/basic.m
+++ b/Tests/CFTree/basic.m
@@ -30,7 +30,28 @@ int main (void)
   PASS_CF(CFTreeGetNextSibling (child1) == child2,
     "Next sibling for child1 is child2.");
   PASS_CF(CFTreeGetChildAtIndex (tree, 2) == child3, "Child3 is at index 2");
-  
+
+  {
+    /* Prepending to an empty tree must set _lastChild, otherwise the next
+       append dereferences NULL.  An out-of-range index must return NULL
+       rather than walking off the end of the child list. */
+    CFTreeRef t2 = CFTreeCreate (NULL, &ctxt);
+    CFTreeRef a = CFTreeCreate (NULL, &ctxt);
+    CFTreeRef b = CFTreeCreate (NULL, &ctxt);
+
+    CFTreePrependChild (t2, a);
+    CFTreeAppendChild (t2, b);
+    PASS_CF(CFTreeGetChildCount (t2) == 2
+      && CFTreeGetChildAtIndex (t2, 1) == b,
+      "Append after prepend-to-empty works.");
+    PASS_CF(CFTreeGetChildAtIndex (t2, 5) == NULL,
+      "Out-of-range child index returns NULL.");
+
+    CFRelease (a);
+    CFRelease (b);
+    CFRelease (t2);
+  }
+
   CFRelease (child1);
   CFRelease (child2);
   CFRelease (child3);


### PR DESCRIPTION
Two ways to crash via the public API:

  * CFTreePrependChild() set tree->_lastChild = NULL (instead of the new
    child) when the tree had no children, so prepending the first child
    left _lastChild NULL.  A subsequent CFTreeAppendChild() then
    dereferenced it (tree->_lastChild->_nextSibling), a NULL write.

  * CFTreeGetChildAtIndex() walked the sibling list without checking for
    the end, so an index past the last child dereferenced NULL.

Set _lastChild to the new child, and stop the walk at the end of the
list (returning NULL for an out-of-range index).  Adds regression tests
(the existing test prepended only after an append, so it never exercised
the empty-tree path).

