### PR TITLE
CFTree: fix CFTreeRemove so it actually unlinks the node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-06-28  Todd White  <todd.white@thalion.global>
+	* Source/CFTree.c (CFTreeRemove): Unlink the node from its parent's
+	list of children (it walked the wrong list and never unlinked,
+	leaving a dangling pointer in the parent), update the parent's
+	_lastChild, and clear the node's _parent and _nextSibling.
+	* Tests/CFTree/basic.m: Regression tests for CFTreeRemove; release
+	the tree before its (unretained) children.
+
 2021-09-30  Frederik Seiffert <frederik@algoriddim.com>
 	* Source/CFDate.c: Fix logic in CFGregorianDateIsValid()
 

--- a/Source/CFTree.c
+++ b/Source/CFTree.c
@@ -195,18 +195,39 @@ CFTreePrependChild (CFTreeRef tree, CFTreeRef newChild)
 void
 CFTreeRemove (CFTreeRef tree)
 {
-  CFTreeRef child;
-  CFTreeRef previousSibling;
-  
-  previousSibling = NULL;
-  child = tree->_firstChild;
-  while (child != previousSibling)
-    child = child->_nextSibling;
-  
-  if (previousSibling)
-    previousSibling->_nextSibling = tree->_nextSibling;
-  
-  CFTreeFinalize (tree);
+  CFTreeRef parent = tree->_parent;
+
+  if (parent == NULL)
+    return;
+
+  /* Unlink the tree from its parent's list of children. */
+  if (parent->_firstChild == tree)
+    {
+      parent->_firstChild = tree->_nextSibling;
+    }
+  else
+    {
+      CFTreeRef previousSibling = parent->_firstChild;
+
+      while (previousSibling != NULL
+             && previousSibling->_nextSibling != tree)
+        previousSibling = previousSibling->_nextSibling;
+      if (previousSibling != NULL)
+        previousSibling->_nextSibling = tree->_nextSibling;
+    }
+
+  /* Fix up the parent's last-child pointer if we removed the last child. */
+  if (parent->_lastChild == tree)
+    {
+      CFTreeRef last = parent->_firstChild;
+
+      while (last != NULL && last->_nextSibling != NULL)
+        last = last->_nextSibling;
+      parent->_lastChild = last;
+    }
+
+  tree->_parent = NULL;
+  tree->_nextSibling = NULL;
 }
 
 void

--- a/Tests/CFTree/basic.m
+++ b/Tests/CFTree/basic.m
@@ -30,11 +30,47 @@ int main (void)
   PASS_CF(CFTreeGetNextSibling (child1) == child2,
     "Next sibling for child1 is child2.");
   PASS_CF(CFTreeGetChildAtIndex (tree, 2) == child3, "Child3 is at index 2");
-  
+
+  {
+    /* CFTreeRemove must unlink the node from its parent.  It used to walk
+       the wrong list, never unlink, and prematurely finalize the node,
+       leaving a dangling pointer in the parent. */
+    CFTreeRef r  = CFTreeCreate (NULL, &ctxt);
+    CFTreeRef r1 = CFTreeCreate (NULL, &ctxt);
+    CFTreeRef r2 = CFTreeCreate (NULL, &ctxt);
+    CFTreeRef r3 = CFTreeCreate (NULL, &ctxt);
+
+    CFTreeAppendChild (r, r1);
+    CFTreeAppendChild (r, r2);
+    CFTreeAppendChild (r, r3);
+
+    CFTreeRemove (r2);
+    PASS_CF(CFTreeGetChildCount (r) == 2
+      && CFTreeGetNextSibling (r1) == r3
+      && CFTreeGetParent (r2) == NULL,
+      "CFTreeRemove unlinks a child from its parent.");
+
+    /* Removing the last child updates _lastChild, so a following append
+       links onto the right node. */
+    CFTreeRemove (r3);
+    CFTreeAppendChild (r, r2);
+    PASS_CF(CFTreeGetChildCount (r) == 2
+      && CFTreeGetChildAtIndex (r, 1) == r2,
+      "Append after removing the last child works.");
+
+    CFRelease (r);
+    CFRelease (r1);
+    CFRelease (r2);
+    CFRelease (r3);
+  }
+
+  /* Release the parent before its children: CFTreeAppendChild() does not
+     retain the child, so the children must outlive the tree that links
+     them. */
+  CFRelease (tree);
   CFRelease (child1);
   CFRelease (child2);
   CFRelease (child3);
-  CFRelease (tree);
-  
+
   return 0;
 }


### PR DESCRIPTION
CFTreeRemove() walked tree->_firstChild (the node's own children) instead
of the parent's child list, and never assigned previousSibling, so the
loop condition "child != previousSibling" simply ran to the end of the
list and nothing was ever unlinked.  It then called CFTreeFinalize() on
the node while the parent still pointed at it.  The node was therefore
left linked into its parent; once it was released the parent held a
dangling pointer (AddressSanitizer: heap-use-after-free in
CFTreeGetChildCount/CFTreeFinalize after removing a child and releasing
it), and the child count was never updated.

Rewrite it to unlink the node from its parent's list of children, fix up
the parent's _lastChild pointer when the last child is removed, and clear
the node's _parent and _nextSibling.  A node with no parent is left
untouched.  Adds regression tests covering removal of the first, middle,
last and only child.

The test also releases the tree before its children now: CFTreeAppendChild
does not retain the child, so a child freed before the tree that links it
would otherwise dangle.

