### PR TITLE
CFData: fix CFDataReplaceBytes length miscalculation (heap overflow)

### DIFF
--- a/Source/CFData.c
+++ b/Source/CFData.c
@@ -342,12 +342,12 @@ CFDataReplaceBytes (CFMutableDataRef d, CFRange range,
     return;
   
   md = (struct __CFMutableData*)d;
-  assert (range.location + range.length <= md->_capacity);
-  
-  newBufLen = range.location + newLength;
+  assert (range.location + range.length <= md->_length);
+
+  newBufLen = md->_length - range.length + newLength;
   CFDataCheckCapacityAndGrow (d, newBufLen);
-  
-  if (newLength != range.length && range.location + range.length < newBufLen)
+
+  if (newLength != range.length && range.location + range.length < md->_length)
     {
       UInt8 *moveFrom = md->_contents + range.location + range.length;
       UInt8 *moveTo = md->_contents + range.location + newLength;

--- a/Tests/CFData/replacebytes.m
+++ b/Tests/CFData/replacebytes.m
@@ -1,0 +1,37 @@
+#include "CoreFoundation/CFData.h"
+#include "../CFTesting.h"
+
+/* CFDataReplaceBytes and CFDataDeleteBytes preserve the tail after the edited range. */
+
+const UInt8 src[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+const UInt8 ins[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+
+int main (void)
+{
+  CFMutableDataRef d;
+  const UInt8 *p;
+
+  /* Grow a middle range: replace (2,3) with 4 bytes -> length 10-3+4 = 11,
+   * tail {5..9} preserved after the inserted bytes. */
+  d = CFDataCreateMutable (NULL, 0);
+  CFDataAppendBytes (d, src, sizeof(src));
+  CFDataReplaceBytes (d, CFRangeMake(2, 3), ins, sizeof(ins));
+  PASS_CF(CFDataGetLength(d) == 11, "Grow replace yields correct length.");
+  p = CFDataGetBytePtr(d);
+  PASS_CF(p[0] == 0 && p[1] == 1, "Prefix preserved.");
+  PASS_CF(p[2] == 0xAA && p[5] == 0xDD, "Inserted bytes present.");
+  PASS_CF(p[6] == 5 && p[10] == 9, "Tail preserved after grow.");
+  CFRelease (d);
+
+  /* Delete a middle range: delete (2,3) -> length 7, tail {5..9} shifts down. */
+  d = CFDataCreateMutable (NULL, 0);
+  CFDataAppendBytes (d, src, sizeof(src));
+  CFDataDeleteBytes (d, CFRangeMake(2, 3));
+  PASS_CF(CFDataGetLength(d) == 7, "Delete yields correct length.");
+  p = CFDataGetBytePtr(d);
+  PASS_CF(p[0] == 0 && p[1] == 1 && p[2] == 5 && p[6] == 9,
+    "Tail preserved after delete.");
+  CFRelease (d);
+
+  return 0;
+}

--- a/Tests/CFData/replacebytes.m
+++ b/Tests/CFData/replacebytes.m
@@ -1,36 +1,37 @@
 #include "CoreFoundation/CFData.h"
 #include "../CFTesting.h"
+#include <string.h>
 
 /* CFDataReplaceBytes and CFDataDeleteBytes preserve the tail after the edited range. */
 
 const UInt8 src[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 const UInt8 ins[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+/* Replace (2,3) with the 4 insert bytes: length grows 10-3+4 = 11. */
+const UInt8 grown[] = { 0, 1, 0xAA, 0xBB, 0xCC, 0xDD, 5, 6, 7, 8, 9 };
+/* Delete (2,3): length shrinks to 7 and the tail shifts down. */
+const UInt8 deleted[] = { 0, 1, 5, 6, 7, 8, 9 };
 
 int main (void)
 {
   CFMutableDataRef d;
   const UInt8 *p;
 
-  /* Grow a middle range: replace (2,3) with 4 bytes -> length 10-3+4 = 11,
-   * tail {5..9} preserved after the inserted bytes. */
   d = CFDataCreateMutable (NULL, 0);
   CFDataAppendBytes (d, src, sizeof(src));
   CFDataReplaceBytes (d, CFRangeMake(2, 3), ins, sizeof(ins));
-  PASS_CF(CFDataGetLength(d) == 11, "Grow replace yields correct length.");
   p = CFDataGetBytePtr(d);
-  PASS_CF(p[0] == 0 && p[1] == 1, "Prefix preserved.");
-  PASS_CF(p[2] == 0xAA && p[5] == 0xDD, "Inserted bytes present.");
-  PASS_CF(p[6] == 5 && p[10] == 9, "Tail preserved after grow.");
+  PASS_CF(CFDataGetLength(d) == (CFIndex)sizeof(grown)
+    && memcmp(p, grown, sizeof(grown)) == 0,
+    "Grow replace keeps the prefix and tail around the inserted bytes.");
   CFRelease (d);
 
-  /* Delete a middle range: delete (2,3) -> length 7, tail {5..9} shifts down. */
   d = CFDataCreateMutable (NULL, 0);
   CFDataAppendBytes (d, src, sizeof(src));
   CFDataDeleteBytes (d, CFRangeMake(2, 3));
-  PASS_CF(CFDataGetLength(d) == 7, "Delete yields correct length.");
   p = CFDataGetBytePtr(d);
-  PASS_CF(p[0] == 0 && p[1] == 1 && p[2] == 5 && p[6] == 9,
-    "Tail preserved after delete.");
+  PASS_CF(CFDataGetLength(d) == (CFIndex)sizeof(deleted)
+    && memcmp(p, deleted, sizeof(deleted)) == 0,
+    "Delete removes the range and shifts the tail down.");
   CFRelease (d);
 
   return 0;


### PR DESCRIPTION
## Summary

`CFDataReplaceBytes` computes the new buffer length as
`range.location + newLength`, which ignores the bytes **after** the replaced
range. When a replace or delete leaves a non-empty tail, the buffer is grown
too small and the subsequent tail `memmove` writes past the allocation
(heap buffer overflow), and the stored length is wrong (the tail is dropped).

This affects `CFDataReplaceBytes`, `CFDataDeleteBytes`, and any replace that
leaves trailing bytes — ordinary `CFMutableData` usage.

## Reproduction (AddressSanitizer)

```c
CFMutableDataRef d = CFDataCreateMutable(NULL, 0);
UInt8 a[20]; CFDataAppendBytes(d, a, 20);            /* length 20 */
UInt8 b[30]; CFDataReplaceBytes(d, CFRangeMake(2,3), b, 30);
/* correct new length = 20 - 3 + 30 = 47 */
```

- **Before:** ASan reports `heap-buffer-overflow WRITE of size 15` in `memmove`
  via `CFDataReplaceBytes` (the buffer is grown to only 32 bytes in
  `CFDataCheckCapacityAndGrow`); `CFDataGetLength` returns 32 instead of 47.
- **After:** length 47, no overflow.

## Fix

Compute the new length as `_length - range.length + newLength`, and base the
range precondition (`assert`) and the tail-move guard on `_length` rather than
`_capacity` / the miscomputed length.

## Test

`Tests/CFData/replacebytes.m` covers a middle grow and a middle delete,
asserting both the resulting length and that the prefix/tail are preserved.
