### PR TITLE
CFData: grow CFMutableData geometrically (fix O(n^2) append)

### DIFF
--- a/Source/CFData.c
+++ b/Source/CFData.c
@@ -245,9 +245,14 @@ CFDataCheckCapacityAndGrow (CFMutableDataRef data, CFIndex capacity)
   
   if (capacity > d->_capacity)
     {
+      /* Grow geometrically so that repeated appends are amortised O(1);
+         exact-size growth made building a CFMutableData O(n^2). */
+      CFIndex newCapacity = d->_capacity + (d->_capacity >> 1);
+      if (newCapacity < capacity)
+        newCapacity = capacity;
       d->_contents = CFAllocatorReallocate (d->_allocator, d->_contents,
-        capacity, 0);
-      d->_capacity = capacity;
+        newCapacity, 0);
+      d->_capacity = newCapacity;
     }
 }
 

--- a/Source/CFData.c
+++ b/Source/CFData.c
@@ -239,17 +239,16 @@ CFDataGetLength (CFDataRef d)
   sizeof(struct __CFMutableData) - sizeof(CFRuntimeBase)
 
 static void
-CFDataCheckCapacityAndGrow (CFMutableDataRef data, CFIndex capacity)
+CFDataCheckCapacityAndGrow (CFMutableDataRef data, CFIndex requiredCapacity)
 {
   struct __CFMutableData *d = (struct __CFMutableData*)data;
-  
-  if (capacity > d->_capacity)
+
+  if (requiredCapacity > d->_capacity)
     {
-      /* Grow geometrically so that repeated appends are amortised O(1);
-         exact-size growth made building a CFMutableData O(n^2). */
+      /* Grow geometrically so that repeated appends are amortised O(1) */
       CFIndex newCapacity = d->_capacity + (d->_capacity >> 1);
-      if (newCapacity < capacity)
-        newCapacity = capacity;
+      if (newCapacity < requiredCapacity)
+        newCapacity = requiredCapacity;
       d->_contents = CFAllocatorReallocate (d->_allocator, d->_contents,
         newCapacity, 0);
       d->_capacity = newCapacity;

--- a/Tests/CFData/geometric_growth.m
+++ b/Tests/CFData/geometric_growth.m
@@ -2,12 +2,9 @@
 #include "CoreFoundation/CFData.h"
 #include "../CFTesting.h"
 
-/* Exercises the CFMutableData growth path.  Building a CFMutableData by many
-   single-byte appends drives CFDataCheckCapacityAndGrow repeatedly; this
-   guards that the geometric-growth reallocation keeps the contents intact
-   (length and bytes) across the reallocations.  (The geometric growth itself
-   is a performance fix -- exact-size growth was O(n^2) -- and is validated by
-   measurement; this test guards the correctness of the growth code.) */
+/* Building a CFMutableData by many single-byte appends drives the capacity
+   reallocation path repeatedly; check that the length and bytes stay intact
+   across the reallocations. */
 
 int main (void)
 {

--- a/Tests/CFData/geometric_growth.m
+++ b/Tests/CFData/geometric_growth.m
@@ -1,0 +1,45 @@
+#include "CoreFoundation/CFBase.h"
+#include "CoreFoundation/CFData.h"
+#include "../CFTesting.h"
+
+/* Exercises the CFMutableData growth path.  Building a CFMutableData by many
+   single-byte appends drives CFDataCheckCapacityAndGrow repeatedly; this
+   guards that the geometric-growth reallocation keeps the contents intact
+   (length and bytes) across the reallocations.  (The geometric growth itself
+   is a performance fix -- exact-size growth was O(n^2) -- and is validated by
+   measurement; this test guards the correctness of the growth code.) */
+
+int main (void)
+{
+  CFMutableDataRef d;
+  const CFIndex n = 20000;
+  CFIndex i;
+  const UInt8 *p;
+  Boolean intact = true;
+
+  d = CFDataCreateMutable (NULL, 0);
+  PASS_CF(d != NULL, "created an empty mutable data");
+
+  for (i = 0; i < n; i++)
+    {
+      UInt8 b = (UInt8)(i & 0xff);
+      CFDataAppendBytes (d, &b, 1);
+    }
+
+  PASS_CF(CFDataGetLength (d) == n,
+    "length is correct after %ld single-byte appends", (long)n);
+
+  p = CFDataGetBytePtr (d);
+  for (i = 0; i < n; i++)
+    {
+      if (p[i] != (UInt8)(i & 0xff))
+        {
+          intact = false;
+          break;
+        }
+    }
+  PASS_CF(intact, "contents are intact across the growth reallocations");
+
+  CFRelease (d);
+  return 0;
+}


### PR DESCRIPTION
## Summary

`CFDataCheckCapacityAndGrow` grew the buffer to **exactly** the requested
size, so building a `CFMutableData` with repeated `CFDataAppendBytes` /
`CFDataReplaceBytes` was **O(n²)** — every append reallocates and copies the
whole buffer. `CFPropertyList` appends fixed-size chunks while parsing
`<data>`/reading files, so reading a large property list was quadratic.

## Fix

Grow by 1.5× (or to the requested capacity, whichever is larger) — matching
the geometric growth `GSMutableString` already uses — so repeated appends are
amortised O(1). No API or behavioural change beyond capacity.

## Measurement (append one byte n times, AddressSanitizer build)

| n | before | after |
|---|--------|-------|
| 10000 | 48.9 ms | 0.5 ms |
| 20000 | 158.3 ms | 0.7 ms |
| 40000 | 563.5 ms | 1.7 ms |

Before, doubling `n` ~quadrupled the time (O(n²)); after, it roughly doubles
(O(n)). At n=40000 that is a ~330× speedup.
