### PR TITLE
CFBitVector: fix multiple correctness bugs

### DIFF
--- a/Source/CFBitVector.c
+++ b/Source/CFBitVector.c
@@ -128,7 +128,7 @@ CFBitVectorGetBitIndex (CFIndex idx)
 CF_INLINE UInt8
 CFBitVectorBitMask (UInt8 mostSig, UInt8 leastSig)
 {
-  return ((0xFF << (7 - leastSig + mostSig)) >> mostSig);
+  return ((UInt8)(0xFF << (7 - leastSig + mostSig)) >> mostSig);
 }
 
 static void
@@ -150,7 +150,7 @@ CFBitVectorOperation (CFBitVectorRef bv, CFRange range,
   /* First byte */
   if (curByte == endByte)
     {
-      mask = CFBitVectorBitMask (startBit, startBit + endBit);
+      mask = CFBitVectorBitMask (startBit, endBit);
       multiByte = false;
     }
   else
@@ -227,7 +227,14 @@ CFBitVectorGetBitAtIndex (CFBitVectorRef bv, CFIndex idx)
 void
 CFBitVectorGetBits (CFBitVectorRef bv, CFRange range, UInt8 *bytes)
 {
-  
+  CFIndex i;
+
+  memset (bytes, 0, CFBitVectorGetByteCount (range.length));
+  for (i = 0 ; i < range.length ; i++)
+    {
+      if (CFBitVectorGetBitAtIndex (bv, range.location + i))
+        bytes[i >> 3] |= (0x80 >> (i & 7));
+    }
 }
 
 CFIndex
@@ -282,12 +289,12 @@ CFBitVectorGetFirstIndexOfBit (CFBitVectorRef bv, CFRange range, CFBit value)
 {
   CFIndex idx;
   
-  for (idx = range.location ; idx < range.length ; idx++)
+  for (idx = range.location ; idx < range.location + range.length ; idx++)
     {
       if (value == CFBitVectorGetBitAtIndex (bv, idx))
         return idx;
     }
-  
+
   return kCFNotFound;
 }
 
@@ -296,7 +303,7 @@ CFBitVectorGetLastIndexOfBit (CFBitVectorRef bv, CFRange range, CFBit value)
 {
   CFIndex idx;
 
-  for (idx = range.location + range.length ; idx < range.location ; idx--)
+  for (idx = range.location + range.length - 1 ; idx >= range.location ; idx--)
     {
       if (value == CFBitVectorGetBitAtIndex (bv, idx))
         return idx;
@@ -321,8 +328,11 @@ CFBitVectorCreateMutable (CFAllocatorRef alloc, CFIndex capacity)
       
       byteCount = CFBitVectorGetByteCount(capacity);
       new->_bytes = CFAllocatorAllocate (alloc, byteCount, 0);
+      new->_byteCount = byteCount;
+      if (new->_bytes)
+        memset (new->_bytes, 0, byteCount);
     }
-  
+
   return new;
 }
 
@@ -406,10 +416,12 @@ CFBitVectorSetCount (CFMutableBitVectorRef bv, CFIndex count)
           
           newBytes = CFAllocatorAllocate (CFGetAllocator(bv), newByteCount, 0);
           memcpy (newBytes, bv->_bytes, bv->_byteCount);
-          
+          memset (newBytes + bv->_byteCount, 0, newByteCount - bv->_byteCount);
+
           CFAllocatorDeallocate (CFGetAllocator(bv), bv->_bytes);
-          
+
           bv->_bytes = newBytes;
+          bv->_byteCount = newByteCount;
           bv->_count = count;
         }
       else

--- a/Source/CFBitVector.c
+++ b/Source/CFBitVector.c
@@ -141,12 +141,15 @@ CFBitVectorOperation (CFBitVectorRef bv, CFRange range,
   CFIndex endBit;
   UInt8 mask;
   Boolean multiByte;
-  
+
+  if (range.length <= 0)
+    return;
+
   curByte = CFBitVectorGetByte (range.location);
   endByte = CFBitVectorGetByte (range.location + range.length - 1);
   startBit = CFBitVectorGetBitIndex (range.location);
   endBit = CFBitVectorGetBitIndex (range.location + range.length - 1);
-  
+
   /* First byte */
   if (curByte == endByte)
     {
@@ -159,7 +162,8 @@ CFBitVectorOperation (CFBitVectorRef bv, CFRange range,
       multiByte = true;
     }
   bv->_bytes[curByte] = func (bv->_bytes[curByte], mask, context);
-  
+  ++curByte;
+
   /* Middle bytes */
   while (curByte < endByte)
     {
@@ -279,7 +283,7 @@ CountZero (UInt8 byte, UInt8 mask, void *context)
 CFIndex
 CFBitVectorGetCountOfBit (CFBitVectorRef bv, CFRange range, CFBit value)
 {
-  CFIndex count;
+  CFIndex count = 0;
   CFBitVectorOperation (bv, range, value ? CountOne : CountZero, &count);
   return count;
 }

--- a/Tests/CFBitVector/general.m
+++ b/Tests/CFBitVector/general.m
@@ -1,0 +1,41 @@
+#include "CoreFoundation/CFBitVector.h"
+#include "../CFTesting.h"
+
+int main (void)
+{
+  CFMutableBitVectorRef bv;
+  UInt8 out[4];
+
+  bv = CFBitVectorCreateMutable (NULL, 0);
+  CFBitVectorSetCount (bv, 16);
+  PASS_CF(CFBitVectorGetCount(bv) == 16, "Count set to 16.");
+
+  /* Newly grown bits start cleared. */
+  PASS_CF(CFBitVectorGetBitAtIndex(bv, 0) == 0
+       && CFBitVectorGetBitAtIndex(bv, 15) == 0, "New bits are 0.");
+
+  /* SetAllBits must set every bit. */
+  CFBitVectorSetAllBits (bv, 1);
+  PASS_CF(CFBitVectorGetBitAtIndex(bv, 0) == 1
+       && CFBitVectorGetBitAtIndex(bv, 15) == 1, "SetAllBits sets all bits.");
+  CFBitVectorSetAllBits (bv, 0);
+
+  /* Set a couple of bits and search within sub-ranges (location > 0). */
+  CFBitVectorSetBitAtIndex (bv, 5, 1);
+  CFBitVectorSetBitAtIndex (bv, 11, 1);
+  PASS_CF(CFBitVectorGetFirstIndexOfBit(bv, CFRangeMake(3, 10), 1) == 5,
+    "GetFirstIndexOfBit honours the range location.");
+  PASS_CF(CFBitVectorGetLastIndexOfBit(bv, CFRangeMake(0, 16), 1) == 11,
+    "GetLastIndexOfBit returns the last set bit.");
+  PASS_CF(CFBitVectorGetFirstIndexOfBit(bv, CFRangeMake(0, 5), 1) == kCFNotFound,
+    "GetFirstIndexOfBit reports no match when the range has none.");
+
+  /* GetBits packs the requested range, most-significant bit first.
+     Range (4,8) covers bits 4..11; the set bits 5 and 11 map to range
+     offsets 1 and 7 -> 0b01000001 = 0x41. */
+  CFBitVectorGetBits (bv, CFRangeMake(4, 8), out);
+  PASS_CF(out[0] == 0x41, "GetBits packs the requested range.");
+
+  CFRelease (bv);
+  return 0;
+}

--- a/Tests/CFBitVector/general.m
+++ b/Tests/CFBitVector/general.m
@@ -4,6 +4,10 @@
 int main (void)
 {
   CFMutableBitVectorRef bv;
+  CFMutableBitVectorRef bv13;
+  CFMutableBitVectorRef bv1;
+  CFMutableBitVectorRef bv0;
+  CFMutableBitVectorRef bvf;
   UInt8 out[4];
 
   bv = CFBitVectorCreateMutable (NULL, 0);
@@ -36,6 +40,63 @@ int main (void)
   CFBitVectorGetBits (bv, CFRangeMake(4, 8), out);
   PASS_CF(out[0] == 0x41, "GetBits packs the requested range.");
 
+  /* A range wider than one byte packs into consecutive output bytes.
+     With bits 5, 9 and 11 set, range (3,11) covers bits 3..13; the set
+     bits map to range offsets 2, 6 and 8, i.e. out[0] = 0x22 (offsets 2
+     and 6) and out[1] = 0x80 (offset 8, the first bit of the next byte). */
+  CFBitVectorSetBitAtIndex (bv, 9, 1);
+  CFBitVectorGetBits (bv, CFRangeMake(3, 11), out);
+  PASS_CF(out[0] == 0x22 && out[1] == 0x80,
+    "GetBits packs a range spanning two bytes.");
+
   CFRelease (bv);
+
+  /* Flipping a range spanning more than one byte must flip each bit exactly
+     once (in particular the first byte must not be processed twice). */
+  bvf = CFBitVectorCreateMutable (NULL, 0);
+  CFBitVectorSetCount (bvf, 16);
+  CFBitVectorFlipBits (bvf, CFRangeMake(0, 16));
+  PASS_CF(CFBitVectorGetCountOfBit(bvf, CFRangeMake(0, 16), 1) == 16,
+    "FlipBits flips every bit of a multi-byte range.");
+  CFBitVectorFlipBits (bvf, CFRangeMake(4, 8));
+  PASS_CF(CFBitVectorGetCountOfBit(bvf, CFRangeMake(0, 16), 1) == 8,
+    "Flipping a sub-range clears exactly that range.");
+  CFRelease (bvf);
+
+  /* A count that is not a multiple of 8 exercises the partial final byte. */
+  bv13 = CFBitVectorCreateMutable (NULL, 0);
+  CFBitVectorSetCount (bv13, 13);
+  PASS_CF(CFBitVectorGetCount(bv13) == 13, "Count set to 13.");
+  CFBitVectorSetAllBits (bv13, 1);
+  PASS_CF(CFBitVectorGetBitAtIndex(bv13, 0) == 1
+       && CFBitVectorGetBitAtIndex(bv13, 12) == 1,
+    "SetAllBits sets every bit of a 13-bit vector.");
+  PASS_CF(CFBitVectorGetCountOfBit(bv13, CFRangeMake(0, 13), 1) == 13,
+    "All 13 bits are counted, ignoring the unused tail of the last byte.");
+  CFBitVectorSetBitAtIndex (bv13, 8, 0);
+  PASS_CF(CFBitVectorGetFirstIndexOfBit(bv13, CFRangeMake(0, 13), 0) == 8,
+    "The single clear bit is found in the partial final byte.");
+  CFRelease (bv13);
+
+  /* A single-bit vector. */
+  bv1 = CFBitVectorCreateMutable (NULL, 0);
+  CFBitVectorSetCount (bv1, 1);
+  PASS_CF(CFBitVectorGetBitAtIndex(bv1, 0) == 0, "Single new bit is 0.");
+  CFBitVectorSetBitAtIndex (bv1, 0, 1);
+  PASS_CF(CFBitVectorGetBitAtIndex(bv1, 0) == 1, "Single bit is set.");
+  PASS_CF(CFBitVectorGetFirstIndexOfBit(bv1, CFRangeMake(0, 1), 1) == 0
+       && CFBitVectorGetLastIndexOfBit(bv1, CFRangeMake(0, 1), 1) == 0,
+    "The single set bit is found by both first and last searches.");
+  CFRelease (bv1);
+
+  /* An empty vector: queries over the empty range are well-defined. */
+  bv0 = CFBitVectorCreateMutable (NULL, 0);
+  PASS_CF(CFBitVectorGetCount(bv0) == 0, "Empty vector has count 0.");
+  PASS_CF(CFBitVectorGetCountOfBit(bv0, CFRangeMake(0, 0), 1) == 0,
+    "The empty range counts no bits.");
+  PASS_CF(CFBitVectorGetFirstIndexOfBit(bv0, CFRangeMake(0, 0), 1) == kCFNotFound,
+    "The empty range finds no set bit.");
+  CFRelease (bv0);
+
   return 0;
 }


### PR DESCRIPTION
## Summary

`CFBitVector` is substantially broken for mutable vectors and for several
query operations. This fixes the bugs exercised by the new
`Tests/CFBitVector/general.m`:

- **`CFBitVectorBitMask`** computed `0xFF << n` in `int` arithmetic and
  right-shifted *before* truncating to a byte, so any mask with `mostSig > 0`
  was wrong — e.g. `CFBitVectorSetBitAtIndex` set several bits instead of one.
  Truncate to `UInt8` first.
- **`CFBitVectorOperation`** single-byte mask used
  `BitMask(startBit, startBit + endBit)` instead of `BitMask(startBit, endBit)`.
- **`CFBitVectorGetBits`** had an empty body; implemented (packs the range,
  MSB first, matching `CFBitVectorGetBitAtIndex`).
- **`CFBitVectorGetFirstIndexOfBit`** looped while `idx < range.length`
  instead of `idx < range.location + range.length`.
- **`CFBitVectorGetLastIndexOfBit`** started at `range.location + range.length`
  with condition `idx < range.location`, so the loop never ran and it always
  returned `kCFNotFound`.
- **Mutable `_byteCount`** was never set (left at 0 by the count-0 immutable
  constructor), so `CFBitVectorSetAllBits` was a no-op and `CFBitVectorSetCount`
  lost the byte count on every grow. Now tracked in `CFBitVectorCreateMutable`
  and `CFBitVectorSetCount`, and newly grown storage is zeroed.

## Test

`Tests/CFBitVector/general.m` covers `SetCount`/`SetAllBits`, single-bit
set/get, `GetFirstIndexOfBit`/`GetLastIndexOfBit` over sub-ranges, and
`GetBits`. It fails on every point above before this change and passes after.
