### PR TITLE
CFNumber: add missing break statements in CFNumberGetType

### DIFF
--- a/Source/CFNumber.c
+++ b/Source/CFNumber.c
@@ -416,22 +416,29 @@ CFNumberGetType (CFNumberRef num)
           case _C_CHR:
           case _C_UCHR:
             cfType = kCFNumberCharType;
+            break;
           case _C_SHT:
           case _C_USHT:
             cfType = kCFNumberShortType;
+            break;
           case _C_INT:
           case _C_UINT:
             cfType = kCFNumberIntType;
+            break;
           case _C_LNG:
           case _C_ULNG:
             cfType = kCFNumberLongType;
+            break;
           case _C_LNG_LNG:
           case _C_ULNG_LNG:
             cfType = kCFNumberLongLongType;
+            break;
           case _C_FLT:
             cfType = kCFNumberFloatType;
+            break;
           case _C_DBL:
             cfType = kCFNumberDoubleType;
+            break;
         }
       return cfType;
     }

--- a/Tests/CFNumber/gettype.m
+++ b/Tests/CFNumber/gettype.m
@@ -1,0 +1,13 @@
+#import <Foundation/NSValue.h>
+#include "CoreFoundation/CFNumber.h"
+#include "../CFTesting.h"
+
+int main (void)
+{
+  NSNumber *i = [NSNumber numberWithInt: 5];
+
+  PASS_CF(CFNumberGetType((CFNumberRef)i) == kCFNumberIntType,
+    "An integer NSNumber reports kCFNumberIntType, not kCFNumberDoubleType.");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

The `objCType` switch in `CFNumberGetType` (the bridged-`NSNumber` path,
`CF_IS_OBJC`) has **no `break` statements**, so every case falls through to
the last (`kCFNumberDoubleType`). A bridged `NSNumber` of any type therefore
reports `kCFNumberDoubleType`, which also gives wrong results for
`CFNumberGetByteSize`, `CFNumberIsFloatType`, and equality of bridged numbers.

## Fix

Add the missing `break` after each case.

## Test

`Tests/CFNumber/gettype.m`: an integer `NSNumber` must report
`kCFNumberIntType`. It returns `kCFNumberDoubleType` before this change and the
correct type after.

(A single integer case is used deliberately: gnustep-base represents small
`long`/`short`/`char` numbers with an `int` objCType, and float/double
`NSNumber`s are tagged pointers that don't bridge through the CF FFI path — so
`int` is the one case that exercises this switch portably.)
