### PR TITLE
CFRuntime: fix off-by-one in type ID bounds checks

### DIFF
--- a/Source/CFRuntime.c
+++ b/Source/CFRuntime.c
@@ -128,7 +128,7 @@ const CFRuntimeClass *
 _CFRuntimeGetClassWithTypeID (CFTypeID typeID)
 {
   GSMutexLock (&_kCFRuntimeTableLock);
-  if (typeID > __CFRuntimeClassTableCount)
+  if (typeID >= __CFRuntimeClassTableCount)
     typeID = 0;
   GSMutexUnlock (&_kCFRuntimeTableLock);
   return __CFRuntimeClassTable[typeID];
@@ -153,7 +153,7 @@ _CFRuntimeCreateInstance (CFAllocatorRef allocator, CFTypeID typeID,
   CFRuntimeBase *new;
 
   /* Return NULL if typeID is unknown. */
-  if (_kCFRuntimeNotATypeID == typeID || typeID > __CFRuntimeClassTableCount)
+  if (_kCFRuntimeNotATypeID == typeID || typeID >= __CFRuntimeClassTableCount)
     {
       return NULL;
     }


### PR DESCRIPTION
## Summary

`_CFRuntimeGetClassWithTypeID` and `_CFRuntimeCreateInstance` rejected a type
ID only when `typeID > __CFRuntimeClassTableCount`. Valid type IDs are
`[0, __CFRuntimeClassTableCount)` — the count is post-incremented when a class
is registered (`ret = __CFRuntimeClassTableCount++`) — so
`typeID == __CFRuntimeClassTableCount` is out of range and indexes an
as-yet-unregistered slot (a NULL/garbage class pointer):

- `_CFRuntimeGetClassWithTypeID` returns `__CFRuntimeClassTable[typeID]` for
  that boundary value instead of resetting to 0.
- `_CFRuntimeCreateInstance` proceeds (rather than returning NULL) and reads
  `__CFRuntimeObjCClassTable[typeID]`.

## Fix

Use `>=`, matching the bounds checks already used elsewhere in the same file
(which test `typeID >= __CFRuntimeClassTableCount`). Two-character change in
two places; the existing test suite still passes.
