### PR TITLE
NSCFString: fix lengthOfBytesUsingEncoding recursion and getCString encoding direction

### DIFF
--- a/Source/NSCFString.m
+++ b/Source/NSCFString.m
@@ -321,13 +321,24 @@ static NSStringEncoding *nsencodings = NULL;
           maxLength: (NSUInteger) maxLength
            encoding: (NSStringEncoding) encoding
 {
-  CFStringEncoding enc = CFStringConvertEncodingToNSStringEncoding (encoding);
+  CFStringEncoding enc = CFStringConvertNSStringEncodingToEncoding (encoding);
   return (BOOL)CFStringGetCString ((CFStringRef) self, buffer, maxLength, enc);
 }
 
 - (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding) encoding
 {
-  return [self lengthOfBytesUsingEncoding: encoding];
+  CFStringEncoding enc = CFStringConvertNSStringEncodingToEncoding (encoding);
+  CFIndex length = CFStringGetLength ((CFStringRef) self);
+  CFIndex max = CFStringGetMaximumSizeForEncoding (length, enc);
+  CFIndex used = 0;
+  UInt8 *buffer = (UInt8 *) malloc (max);
+
+  if (buffer == NULL)
+    return 0;
+  CFStringGetBytes ((CFStringRef) self, CFRangeMake (0, length), enc, 0,
+                    false, buffer, max, &used);
+  free (buffer);
+  return (NSUInteger) used;
 }
 
 - (NSUInteger) maximumLengthOfBytesUsingEncoding: (NSStringEncoding) encoding

--- a/Tests/CFString/bridge_encoding.m
+++ b/Tests/CFString/bridge_encoding.m
@@ -1,0 +1,25 @@
+#import <Foundation/NSString.h>
+#include "CoreFoundation/CFString.h"
+#include "../CFTesting.h"
+#include <string.h>
+
+/* NSCFString lengthOfBytesUsingEncoding: and getCString:maxLength:encoding:. */
+
+int main (void)
+{
+  NSString *s =
+    (NSString *) CFStringCreateWithCString (NULL, "hello",
+                                            kCFStringEncodingASCII);
+  char buf[16];
+  BOOL ok;
+
+  PASS_CF([s lengthOfBytesUsingEncoding: NSASCIIStringEncoding] == 5,
+    "lengthOfBytesUsingEncoding: returns the byte count.");
+
+  ok = [s getCString: buf maxLength: sizeof(buf) encoding: NSASCIIStringEncoding];
+  PASS_CF(ok == YES, "getCString:maxLength:encoding: succeeds for ASCII.");
+  PASS_CF(strcmp(buf, "hello") == 0, "getCString fills the buffer correctly.");
+
+  CFRelease ((CFStringRef) s);
+  return 0;
+}


### PR DESCRIPTION
## Summary

Two bugs in the bridged-`CFString` (`NSCFString`) encoding methods:

1. **`lengthOfBytesUsingEncoding:`** called itself unconditionally:

   ```objc
   - (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding) encoding
   {
     return [self lengthOfBytesUsingEncoding: encoding];   // infinite recursion
   }
   ```

   This recurses until the stack overflows. Implemented by converting the
   string with `CFStringGetBytes` and returning the number of bytes used.

2. **`getCString:maxLength:encoding:`** converted its `NSStringEncoding`
   argument with `CFStringConvertEncodingToNSStringEncoding` (the *CF→NS*
   direction) before passing it to `CFStringGetCString`, which expects a
   `CFStringEncoding`. Use `CFStringConvertNSStringEncodingToEncoding`, the same
   direction the neighbouring methods (`initWithBytes:`,
   `maximumLengthOfBytesUsingEncoding:`, …) already use.

## Test

`Tests/CFString/bridge_encoding.m` builds a bridged `CFString` and checks
`lengthOfBytesUsingEncoding:` (which previously crashed) and
`getCString:maxLength:encoding:`.

## Note

`dataUsingEncoding:allowLossyConversion:` has the same reversed conversion, but
it cannot currently be exercised end-to-end because
`CFStringCreateExternalRepresentation` returns NULL for these encodings — a
separate issue, so it is left out of this change.
