### PR TITLE
CFPropertyList: fix CFPropertyListCreateDeepCopy of mutable containers

### DIFF
--- a/Source/CFPropertyList.c
+++ b/Source/CFPropertyList.c
@@ -257,6 +257,7 @@ CFPropertyListCreateDeepCopy (CFAllocatorRef alloc, CFPropertyListRef plist,
   CFPropertyListRef copy;
   CFTypeID typeID;
 
+  CFPropertyListInitTypeIDs ();
   typeID = CFGetTypeID (plist);
   if (typeID == _kCFArrayTypeID)
     {
@@ -293,7 +294,7 @@ CFPropertyListCreateDeepCopy (CFAllocatorRef alloc, CFPropertyListRef plist,
           ctx.alloc = alloc;
           ctx.container = (CFTypeRef) array;
           range = CFRangeMake (0, cnt);
-          CFArrayApplyFunction (array, range, CFArrayCopyFunction, &ctx);
+          CFArrayApplyFunction (plist, range, CFArrayCopyFunction, &ctx);
 
           copy = array;
         }
@@ -338,7 +339,7 @@ CFPropertyListCreateDeepCopy (CFAllocatorRef alloc, CFPropertyListRef plist,
           ctx.opts = opts;
           ctx.alloc = alloc;
           ctx.container = (CFTypeRef) dict;
-          CFDictionaryApplyFunction (dict, CFDictionaryCopyFunction, &ctx);
+          CFDictionaryApplyFunction (plist, CFDictionaryCopyFunction, &ctx);
 
           copy = dict;
         }

--- a/Tests/CFPropertyList/deepcopy.m
+++ b/Tests/CFPropertyList/deepcopy.m
@@ -1,0 +1,41 @@
+#include "CoreFoundation/CFPropertyList.h"
+#include "CoreFoundation/CFArray.h"
+#include "CoreFoundation/CFDictionary.h"
+#include "CoreFoundation/CFString.h"
+#include "../CFTesting.h"
+
+/* CFPropertyListCreateDeepCopy of mutable containers. */
+
+int main (void)
+{
+  CFMutableArrayRef arr;
+  CFArrayRef acopy;
+  CFMutableDictionaryRef dict;
+  CFDictionaryRef dcopy;
+
+  arr = CFArrayCreateMutable (NULL, 0, &kCFTypeArrayCallBacks);
+  CFArrayAppendValue (arr, CFSTR ("a"));
+  CFArrayAppendValue (arr, CFSTR ("b"));
+  acopy = CFPropertyListCreateDeepCopy (NULL, arr,
+                                        kCFPropertyListMutableContainers);
+  PASS_CF(acopy != NULL && CFArrayGetCount (acopy) == 2,
+    "Deep copy of a mutable array has 2 elements.");
+  PASS_CF(CFArrayGetCount (acopy) == 2
+    && CFEqual (CFArrayGetValueAtIndex (acopy, 0), CFSTR ("a"))
+    && CFEqual (CFArrayGetValueAtIndex (acopy, 1), CFSTR ("b")),
+    "Deep-copied array elements are preserved.");
+
+  dict = CFDictionaryCreateMutable (NULL, 0,
+                                    &kCFCopyStringDictionaryKeyCallBacks,
+                                    &kCFTypeDictionaryValueCallBacks);
+  CFDictionarySetValue (dict, CFSTR ("k"), CFSTR ("v"));
+  dcopy = CFPropertyListCreateDeepCopy (NULL, dict,
+                                        kCFPropertyListMutableContainers);
+  PASS_CF(dcopy != NULL && CFDictionaryGetCount (dcopy) == 1,
+    "Deep copy of a mutable dictionary has 1 entry.");
+  PASS_CF(CFDictionaryGetCount (dcopy) == 1
+    && CFEqual (CFDictionaryGetValue (dcopy, CFSTR ("k")), CFSTR ("v")),
+    "Deep-copied dictionary value is preserved.");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

`CFPropertyListCreateDeepCopy` could not deep-copy a mutable array or
dictionary, for two reasons:

1. **Type IDs never initialised on this path.** `CFPropertyListInitTypeIDs`
   (which lazily fills `_kCFArrayTypeID`, `_kCFDictionaryTypeID`, …) was only
   called from the validation code. On a standalone `CFPropertyListCreateDeepCopy`
   call, every `CFGetTypeID(...) == _kCF*TypeID` comparison saw `0`, no branch
   matched, and the function returned **NULL**.

2. **Copy applied over the empty destination.** Once the type IDs are
   initialised, the mutable array and dictionary branches applied their copy
   function over the freshly-created (empty) destination container instead of
   the source `plist`:

   ```c
   array = CFArrayCreateMutable (alloc, cnt, ...);   /* empty */
   CFArrayApplyFunction (array, range, CFArrayCopyFunction, &ctx);  /* <- wrong */
   ```

   so the result came back **empty** (and iterating the empty array over
   `range (0, cnt)` was itself out of range).

## Fix

Call `CFPropertyListInitTypeIDs()` at the top, and apply the copy functions
over the source `plist`.

## Test

`Tests/CFPropertyList/deepcopy.m`: deep-copying a mutable array and a mutable
dictionary preserves their elements.
