### PR TITLE
CFRunLoop: search the sources array with its own count when removing invalidated sources

### DIFF
--- a/Source/CFRunLoop.c
+++ b/Source/CFRunLoop.c
@@ -1521,7 +1521,7 @@ CFRunLoopSourceRemoveInvalidated(const void *key, const void *value, void *sourc
 {
   GSRunLoopContextRef ctxt = (GSRunLoopContextRef) value;
   CFIndex idx = CFArrayGetFirstIndexOfValue(ctxt->sources0,
-                                            CFRangeMake(0, CFArrayGetCount(ctxt->timers)),
+                                            CFRangeMake(0, CFArrayGetCount(ctxt->sources0)),
                                             (CFRunLoopSourceRef) source);
   
   if (idx != -1)

--- a/Tests/CFRunLoop/source_invalidate.m
+++ b/Tests/CFRunLoop/source_invalidate.m
@@ -1,0 +1,32 @@
+#include "CoreFoundation/CFRunLoop.h"
+#include "../CFTesting.h"
+#include <string.h>
+
+/* Removing an invalidated CFRunLoopSource from the run loop. */
+
+static void perform (void *info)
+{
+}
+
+int main (void)
+{
+  CFRunLoopRef rl;
+  CFRunLoopSourceContext ctx;
+  CFRunLoopSourceRef src;
+
+  rl = CFRunLoopGetCurrent ();
+  memset (&ctx, 0, sizeof (ctx));
+  ctx.perform = perform;
+  src = CFRunLoopSourceCreate (NULL, 0, &ctx);
+  CFRunLoopAddSource (rl, src, kCFRunLoopDefaultMode);
+  PASS_CF(CFRunLoopContainsSource (rl, src, kCFRunLoopDefaultMode) == true,
+    "Source is in the run loop after being added.");
+
+  /* No timers are registered. */
+  CFRunLoopSourceInvalidate (src);
+  PASS_CF(CFRunLoopContainsSource (rl, src, kCFRunLoopDefaultMode) == false,
+    "Invalidated source is removed from the run loop.");
+
+  CFRelease (src);
+  return 0;
+}

--- a/Tests/CFRunLoop/source_invalidate.m
+++ b/Tests/CFRunLoop/source_invalidate.m
@@ -2,8 +2,6 @@
 #include "../CFTesting.h"
 #include <string.h>
 
-/* Removing an invalidated CFRunLoopSource from the run loop. */
-
 static void perform (void *info)
 {
 }


### PR DESCRIPTION
## Summary

`CFRunLoopSourceRemoveInvalidated` searched the `sources0` array using the
count of the **timers** array:

```c
CFIndex idx = CFArrayGetFirstIndexOfValue(ctxt->sources0,
                                          CFRangeMake(0, CFArrayGetCount(ctxt->timers)),
                                          (CFRunLoopSourceRef) source);
```

With no timers registered the search range was `(0, 0)`, so an invalidated
version-0 source was never found and never removed from the run loop (it also
stayed in `sources0set`, so `CFRunLoopContainsSource` kept returning true). When
there were more timers than sources, the range ran past the end of the
`sources0` array.

## Fix

Use `CFArrayGetCount(ctxt->sources0)`, matching the timer-removal path
(`CFRunLoopTimerRemoveInvalidated`).

## Test

`Tests/CFRunLoop/source_invalidate.m`: add a version-0 source (no timers),
invalidate it, and confirm `CFRunLoopContainsSource` returns false.
