### PR TITLE
CFTimeZone: lock the timezone-cache lookup (data race)

### DIFF
--- a/Source/CFTimeZone.c
+++ b/Source/CFTimeZone.c
@@ -141,18 +141,13 @@ CFTimeZoneCreate (CFAllocatorRef alloc, CFStringRef name, CFDataRef data)
   struct __CFTimeZone *new;
   CFTimeZoneRef old;
   
+  GSMutexLock(&_kCFTimeZoneCacheLock);
   if (_kCFTimeZoneCache == NULL)
-    {
-      GSMutexLock(&_kCFTimeZoneCacheLock);
-      /* Double check the cache is still NULL. */
-      if (_kCFTimeZoneCache == NULL)
-        _kCFTimeZoneCache = CFDictionaryCreateMutable (
-          kCFAllocatorSystemDefault, 0,
-          &kCFCopyStringDictionaryKeyCallBacks, NULL);
-      GSMutexUnlock(&_kCFTimeZoneCacheLock);
-    }
-  /* Verify we haven't created a timezone with this name already. */
+    _kCFTimeZoneCache = CFDictionaryCreateMutable (
+      kCFAllocatorSystemDefault, 0,
+      &kCFCopyStringDictionaryKeyCallBacks, NULL);
   old = (CFTimeZoneRef)CFDictionaryGetValue (_kCFTimeZoneCache, name);
+  GSMutexUnlock(&_kCFTimeZoneCacheLock);
   if (old != NULL)
     return CFRetain (old);
   


### PR DESCRIPTION
## Summary

`CFTimeZoneCreate` looked up the global timezone cache without holding the
cache lock:

```c
old = (CFTimeZoneRef)CFDictionaryGetValue (_kCFTimeZoneCache, name);  /* unlocked */
```

while the insert path adds entries — which can rehash the dictionary — under
`_kCFTimeZoneCacheLock`. Concurrent `CFTimeZoneCreate` / `CFTimeZoneCreateWithName`
calls therefore race on the dictionary's internal bucket array, and the lazy
cache creation was double-checked with an unsynchronised pointer read.

## Reproduction (ThreadSanitizer)

Built libgnustep-corebase with `-fsanitize=thread`; 8 threads call
`CFTimeZoneCreateWithName` with distinct zone names (abbreviation dictionary
pre-warmed to isolate this race). TSan reports:

```
WARNING: ThreadSanitizer: data race
  Read  ... GSHashTableFindBucket / GSHashTableGetValue
        <- CFDictionaryGetValue <- CFTimeZoneCreate (CFTimeZone.c:155)
  Write ... GSHashTableCreateMutable (mutex held)
        <- CFDictionaryCreateMutable <- CFTimeZoneCreate (CFTimeZone.c:149)
```

## Fix

Create the cache and look up the entry under `_kCFTimeZoneCacheLock`. The
insert path already re-checks under the lock, so the slow path is unchanged.

After the change the `CFTimeZoneCreate` cache race no longer appears under the
same TSan harness.
