### PR TITLE
CFString: lock the constant-string table lookup (data race)

### DIFF
--- a/Source/CFString.c
+++ b/Source/CFString.c
@@ -258,27 +258,14 @@ __CFStringMakeConstantString (const char *str)
 {
   CFStringRef old;
 
-  if (static_strings == NULL)
-    {
-      /* The 170 capacity is really arbitrary.  I just wanted to make the
-       * number large enough so that the hash table size comes out to 257,
-       * a table large enough to fit most needs before needing to expand.
-       */
-      GSMutexLock (&static_strings_lock);
-      if (static_strings == NULL)
-        static_strings = CFDictionaryCreateMutable (NULL, 170, NULL, NULL);
-      GSMutexUnlock (&static_strings_lock);
-    }
-
-  old = (CFStringRef) CFDictionaryGetValue (static_strings, str);
-
-  /* Return the existing string pointer if we have one. */
-  if (NULL != old)
-    return old;
-
   GSMutexLock (&static_strings_lock);
-  /* Check again in case another thread added this string to the table while
-   * we were waiting on the mutex. */
+  /* The 170 capacity is really arbitrary.  I just wanted to make the
+   * number large enough so that the hash table size comes out to 257,
+   * a table large enough to fit most needs before needing to expand.
+   */
+  if (static_strings == NULL)
+    static_strings = CFDictionaryCreateMutable (NULL, 170, NULL, NULL);
+
   old = (CFStringRef) CFDictionaryGetValue (static_strings, str);
   if (NULL == old)
     {


### PR DESCRIPTION
## Summary

`__CFStringMakeConstantString` (which `CFSTR(x)` expands to) looked up — and
lazily created — the global `static_strings` table **outside**
`static_strings_lock`, taking the lock only for the insert:

```c
old = (CFStringRef) CFDictionaryGetValue (static_strings, str);  /* unlocked */
if (NULL != old) return old;
GSMutexLock (&static_strings_lock);
... CFDictionaryAddValue (static_strings, ...);                  /* locked, may rehash */
```

Concurrent `CFSTR` use therefore races: the unlocked `CFDictionaryGetValue`
read can observe the table while a concurrent insert is rehashing (and
reallocating) it, and the lazy-creation `static_strings == NULL` check is an
unsynchronised read of the table pointer.

## Reproduction (ThreadSanitizer)

Built libgnustep-corebase with `-fsanitize=thread`; a multi-thread workload
that interns constant strings reports **25** `__CFStringMakeConstantString`
race references (in `GSHashTableFindBucket` / the `static_strings` pointer read)
against the master build.

## Fix

Do the whole operation — create, look up and insert — under
`static_strings_lock`.

After the change the `__CFStringMakeConstantString` races drop to **0** under
the same harness. (The previous unlocked fast path avoided one mutex
acquisition per lookup; if that becomes a contention point a reader/writer lock
would be the natural follow-up.)
