### PR TITLE
CFString: lock CFStringGetSystemEncoding fully (data race)

### DIFF
--- a/Source/CFStringEncoding.c
+++ b/Source/CFStringEncoding.c
@@ -614,34 +614,31 @@ CFStringGetSystemEncoding (void)
 #if defined(_WIN32)
   return kCFStringEncodingASCII;
 #else
+  GSMutexLock (&_kCFStringEncodingLock);
   if (_kCFStringSystemEncoding == kCFStringEncodingInvalidId)
     {
-      GSMutexLock (&_kCFStringEncodingLock);
-      if (_kCFStringSystemEncoding == kCFStringEncodingInvalidId)
-        {
-          const char *name;
-          const char *defaultName;
-          UErrorCode err = U_ZERO_ERROR;
+      const char *name;
+      const char *defaultName;
+      UErrorCode err = U_ZERO_ERROR;
 
-          defaultName = ucnv_getDefaultName ();
-          name = ucnv_getStandardName (defaultName, "MIME", &err);
-          if (name != NULL)
-            {
-              _kCFStringSystemEncoding =
-                CFStringConvertStandardNameToEncoding (name, -1);
-            }
-          else
-            {
-              name = ucnv_getStandardName (defaultName, "IANA", &err);
-              if (name != NULL)
-                _kCFStringSystemEncoding =
-                  CFStringConvertStandardNameToEncoding (name, -1);
-              else
-                _kCFStringSystemEncoding = kCFStringEncodingInvalidId;
-            }
+      defaultName = ucnv_getDefaultName ();
+      name = ucnv_getStandardName (defaultName, "MIME", &err);
+      if (name != NULL)
+        {
+          _kCFStringSystemEncoding =
+            CFStringConvertStandardNameToEncoding (name, -1);
         }
-      GSMutexUnlock (&_kCFStringEncodingLock);
+      else
+        {
+          name = ucnv_getStandardName (defaultName, "IANA", &err);
+          if (name != NULL)
+            _kCFStringSystemEncoding =
+              CFStringConvertStandardNameToEncoding (name, -1);
+          else
+            _kCFStringSystemEncoding = kCFStringEncodingInvalidId;
+        }
     }
+  GSMutexUnlock (&_kCFStringEncodingLock);
   return _kCFStringSystemEncoding;
 #endif
 }


### PR DESCRIPTION
## Summary

`CFStringGetSystemEncoding` read `_kCFStringSystemEncoding` **outside**
`_kCFStringEncodingLock` — both on the double-checked fast path and again for
the returned value — while the lazy initialisation writes it under the lock:

```c
if (_kCFStringSystemEncoding == kCFStringEncodingInvalidId)   /* unlocked read */
  {
    GSMutexLock (&_kCFStringEncodingLock);
    if (_kCFStringSystemEncoding == kCFStringEncodingInvalidId)
      _kCFStringSystemEncoding = ...;                          /* locked write  */
    GSMutexUnlock (&_kCFStringEncodingLock);
  }
return _kCFStringSystemEncoding;                                /* unlocked read */
```

Concurrent first calls race: ThreadSanitizer flags the unsynchronised reads
against the locked write.

## Reproduction (ThreadSanitizer)

Built libgnustep-corebase with `-fsanitize=thread`; a multi-thread workload
reports a data race in `CFStringGetSystemEncoding` against the master build.

## Fix

Take `_kCFStringEncodingLock` for the whole lookup, read the value into a local
under the lock and return that. After the change the race no longer appears
under the same harness.
