### PR TITLE
CFTimeZone: retain timezones stored in the name cache (use-after-free)

### DIFF
--- a/Source/CFTimeZone.c
+++ b/Source/CFTimeZone.c
@@ -148,7 +148,8 @@ CFTimeZoneCreate (CFAllocatorRef alloc, CFStringRef name, CFDataRef data)
       if (_kCFTimeZoneCache == NULL)
         _kCFTimeZoneCache = CFDictionaryCreateMutable (
           kCFAllocatorSystemDefault, 0,
-          &kCFCopyStringDictionaryKeyCallBacks, NULL);
+          &kCFCopyStringDictionaryKeyCallBacks,
+          &kCFTypeDictionaryValueCallBacks);
       GSMutexUnlock(&_kCFTimeZoneCacheLock);
     }
   /* Verify we haven't created a timezone with this name already. */

--- a/Tests/CFTimeZone/cache_retain.m
+++ b/Tests/CFTimeZone/cache_retain.m
@@ -1,0 +1,42 @@
+#include "CoreFoundation/CFBase.h"
+#include "CoreFoundation/CFTimeZone.h"
+#include "../CFTesting.h"
+
+/* Regression test for the time-zone name cache use-after-free.
+
+   CFTimeZoneCreate caches every created zone in the global name cache.
+   When the cache stored the zone without retaining it, releasing the
+   caller's only reference deallocated the object while the cache still
+   held a dangling pointer to it; the next lookup of the same name then
+   returned and retained freed memory.  AddressSanitizer flags this as a
+   heap-use-after-free in CFRetain/CFGetTypeID on the second create. */
+
+int main (void)
+{
+  CFTimeZoneRef tz1;
+  CFTimeZoneRef tz2;
+  CFStringRef name = CFSTR("America/New_York");
+
+  tz1 = CFTimeZoneCreateWithName (NULL, name, false);
+  if (tz1 == NULL)
+    {
+      /* zoneinfo for this name is not installed; nothing to exercise */
+      PASS_CF(1, "zoneinfo for America/New_York unavailable, skipping");
+      return 0;
+    }
+
+  /* Drop our only reference.  With the bug the cached entry is now a
+     dangling pointer. */
+  CFRelease (tz1);
+
+  /* Look the same name up again: the cache must own a live reference. */
+  tz2 = CFTimeZoneCreateWithName (NULL, name, false);
+  PASS_CF(tz2 != NULL,
+    "re-creating a released cached time zone returns a valid object");
+  PASS_CFEQ(CFTimeZoneGetName (tz2), name,
+    "the re-created time zone has the expected name");
+
+  CFRelease (tz2);
+
+  return 0;
+}

--- a/Tests/CFTimeZone/cache_retain.m
+++ b/Tests/CFTimeZone/cache_retain.m
@@ -2,14 +2,7 @@
 #include "CoreFoundation/CFTimeZone.h"
 #include "../CFTesting.h"
 
-/* Regression test for the time-zone name cache use-after-free.
-
-   CFTimeZoneCreate caches every created zone in the global name cache.
-   When the cache stored the zone without retaining it, releasing the
-   caller's only reference deallocated the object while the cache still
-   held a dangling pointer to it; the next lookup of the same name then
-   returned and retained freed memory.  AddressSanitizer flags this as a
-   heap-use-after-free in CFRetain/CFGetTypeID on the second create. */
+/* Regression test for the time-zone name cache use-after-free. */
 
 int main (void)
 {
@@ -25,8 +18,7 @@ int main (void)
       return 0;
     }
 
-  /* Drop our only reference.  With the bug the cached entry is now a
-     dangling pointer. */
+  /* Drop our own reference; the cache must still hold a live one. */
   CFRelease (tz1);
 
   /* Look the same name up again: the cache must own a live reference. */


### PR DESCRIPTION
## Summary

`CFTimeZoneCreate` caches every timezone it builds in `_kCFTimeZoneCache`, but
the cache is created with **NULL value callbacks**, so it does not retain the
stored objects:

```c
_kCFTimeZoneCache = CFDictionaryCreateMutable (
  kCFAllocatorSystemDefault, 0,
  &kCFCopyStringDictionaryKeyCallBacks, NULL);   /* values not retained */
```

A later call returns the cached entry via `CFRetain(old)`. Once the original
owner releases its reference, the timezone is deallocated **while the cache
still holds a dangling pointer to it**. The next lookup of the same name returns
freed memory, and the `CFRetain` on that pointer dereferences it through
`CFGetTypeID` — a use-after-free.

There is no removal path: `CFTimeZoneFinalize` does not touch the cache, and
nothing calls `CFDictionaryRemoveValue` on it. So the only correct lifetime is
for the cache to own a reference to each entry.

## Fix

Give the cache `kCFTypeDictionaryValueCallBacks` so it retains the timezones it
stores. The cache then behaves as an intern table holding one reference per
distinct zone name for the process lifetime (bounded by the number of zone
names). The insert path returns the original creation reference, so the caller
still receives the `+1` it expects — no double-retain, no leaked caller
reference.

## Reproduction (ThreadSanitizer)

A multi-threaded harness that creates and releases timezones by name aborts with
a `heap-use-after-free` in `CFGetTypeID` (reached from `CFTimeZoneCreate`'s
`CFRetain` of a cached entry). With this change that use-after-free no longer
occurs.

## Relationship to #64

This is a **distinct** bug from the cache-lock race in #64. #64 fixes the
unlocked `CFDictionaryGetValue` racing a concurrent insert's rehash (a
bucket-array race inside the dictionary); this fixes the lifetime of the stored
*objects*. They are complementary — with **both** applied the harness above runs
fully clean under TSan (0 data races, 0 use-after-free, 0 SEGV).

Note: both touch the same `CFDictionaryCreateMutable` call, so whichever lands
first leaves a trivial one-line rebase for the other (the `NULL` →
`&kCFTypeDictionaryValueCallBacks` argument on the relocated call).
